### PR TITLE
Sustituidos varios logos counha tipografía de simbolos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.otf filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text

--- a/fontes/EulerMath/Euler-Math.otf
+++ b/fontes/EulerMath/Euler-Math.otf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a2337c91c95a907255a8d462a6fc865e7fe116075bc7971ff021b4e0a1e6cb2
-size 428584

--- a/fontes/NerdFonts/SymbolsNerdFontMono-Regular.ttf
+++ b/fontes/NerdFonts/SymbolsNerdFontMono-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f14415832a929155c3d6d1c7d404fae00dfbfe4f1b29940e3736e6e790e3312
+size 2333488

--- a/indice.tex
+++ b/indice.tex
@@ -71,7 +71,7 @@ Non dubidedes en deixar a vosa pegada!
     \imprimeParticipantes \\[1.5cm]
     % Links varios
     \begin{tikzpicture}[scale=1.5]
-        \node at (0,0) {\FonteSimbolos\fontsize{15pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        \node at (0,0) {\FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \begingroup
             \hypersetup{urlcolor = TextoEnResalte}
             \node[
@@ -82,7 +82,7 @@ Non dubidedes en deixar a vosa pegada!
                 \textbf{\textcolor{TextoEnResalte}{\href{https://github.com/DAF-USC/revista}{GitHub}}}
             };
         \endgroup
-        \node at (0,-1) { \FonteSimbolos\fontsize{15pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        \node at (0,-1) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \node[
             anchor = west,
             align  = left

--- a/indice.tex
+++ b/indice.tex
@@ -71,7 +71,7 @@ Non dubidedes en deixar a vosa pegada!
     \imprimeParticipantes \\[1.5cm]
     % Links varios
     \begin{tikzpicture}[scale=1.5]
-        \node at (0,0) {\includegraphics[width=0.7cm]{logos/github-branco.png}};
+        \node at (0,0) {\FonteSimbolos\fontsize{15pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \begingroup
             \hypersetup{urlcolor = TextoEnResalte}
             \node[
@@ -82,7 +82,7 @@ Non dubidedes en deixar a vosa pegada!
                 \textbf{\textcolor{TextoEnResalte}{\href{https://github.com/DAF-USC/revista}{GitHub}}}
             };
         \endgroup
-        \node at (0,-1) {\includegraphics[width=0.7cm]{logos/icona-email.png}};
+        \node at (0,-1) { \FonteSimbolos\fontsize{15pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \node[
             anchor = west,
             align  = left

--- a/logos/github-branco.png
+++ b/logos/github-branco.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6c4535a9e0fd30dafa403e92adb12f00b3ba8bf728610fb6fd96247e8d28684
-size 24945

--- a/logos/icona-email.png
+++ b/logos/icona-email.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6678afe55d2378fb8f56c8faafb9a4cce5284f4d4b1703a8030e0305a06d2d7d
-size 26185

--- a/logos/icona-facebook.png
+++ b/logos/icona-facebook.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:113bb362b0b867751f2d1be911a68432648ed3b50380a1614ef2c7416466cfdf
-size 26118

--- a/logos/icona-insta.png
+++ b/logos/icona-insta.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d7c6bc62d194b6fa77ca049f9a66ad8f13135a7eb416bab78432920ecc92fb8
-size 49393

--- a/logos/icona-web.png
+++ b/logos/icona-web.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c15f18d63591cf07fed7b21fccd2bea972764a428e481a1c16df7ca44ba55e6
-size 49384

--- a/logos/icona-x.png
+++ b/logos/icona-x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:401355ff791a988e76f8c076598bcbb562015d9736be74cef957469ad58ba6b3
-size 39387

--- a/revista.cls
+++ b/revista.cls
@@ -37,6 +37,23 @@
 % 'unicode-math' máis abaixo. A cousa é que primeiro hai que cargar os paquetes
 % de matemáticas e DESPOIS, unicode-math
 
+% Esta é unha familia de fontes. Podemos activala facendo, dentro de parénteses
+% { \FonteSimbolos bla bla bla ... }
+% A peculiaridade é que esta fonte non ten letras, só símbolos. A idea é usala
+% para sustituir as imaxes .PNG de cousas como mails,twitter,instagram, etc.
+% Pra usar un símbolo so hai que copialo e pegalo nun entorno onde activásemos
+% esta tipografía. Para buscar os iconos: https://www.nerdfonts.com/cheat-sheet
+% É bastante posible que o editor que estedes usando non vos mostre o icono na
+% pantalla correctamente. Non é problema, mentres sexa o icono correcto no PDF
+% verase ben. Tamén é posible especificar o icono co seu código hexadecimal
+% explícitamente, escribindo ^^^^eb2a Sí, os catro ^ son necesarios, 'eb2a' é o
+% codigo hex.
+\newfontfamily{\FonteSimbolos}[
+    Extension   = .ttf,
+    UprightFont = *-Regular,
+    Path        = ./fontes/NerdFonts/,
+]{SymbolsNerdFontMono}
+
 % Usar galego (como debe ser)
 \RequirePackage[galician]{babel}
 % Usar babel pode fastidiar as citas con biblatex, asique hai que usar


### PR DESCRIPTION
Engadida a tipografía SymbolsNerdFontMono-Regular.ttf que contén uns 10.000 iconos. Podemos usar estos en vez de varios .PNG para cousas pequenas e típicas como iconos de mails, whatsapp, instagram, etc.

- Cambiaronse as imaxes cos macros correspondentes no índice
- Eliminaronse as imaxes dos iconos
- Tamén se eliminou a tipografía vella EulerMath (non a usamos)