### PR TITLE
Cambiados moitos textos por macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,25 @@ forma seguinte (aproximada)
 \Numero{001}
 \Data{Xaneiro do 1900}
 \ImaxePortada{./revistas/001/imaxes/cern.png}
-\definecolor{Resalte}{HTML}{ff0000} % cores especificos de cada revista
-\definecolor{TextoEnResalte}{HTML}{000000}
+\ComentarioImaxePortada{ Imaxe da portada }
+\CorResalte{ff0000} % cores especificos de cada revista, con codigos HTML hex
+\CorTextoEnResalte{000000}
+\LinkRepositorio{ guthib.com }
+\Correo{ correo@correo.correo }
+\SobreMomentum{ Esta é a revista momentum! }
 \Participantes{
     {\Large \textbf{Dirección:}}     \\[0.5cm]
         Carl Sagan                   \\[0.2cm]
-        ...                          \\[0.2cm]
     {\Large \textbf{Edición}}        \\[0.5cm]
         Albert Einstein              \\[0.2cm]
     {\Large \textbf{Diseño de Logo}} \\[0.5cm]
         Dirac                        \\[0.2cm]
-} }
+}
+\Despedida{ Adeus! }
+\Agradecementos{ Grazas a Todos! }
+\Drive{ https://linkaodrive.com }
+\WhatsApp{ https://link grupo whatsapp }
+
 \begin{document}
 \input{portada.tex}
 \input{indice.tex}

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ forma seguinte (aproximada)
 \ComentarioImaxePortada{ Imaxe da portada }
 \CorResalte{ff0000} % cores especificos de cada revista, con codigos HTML hex
 \CorTextoEnResalte{000000}
-\LinkRepositorio{ guthib.com }
-\Correo{ correo@correo.correo }
 \SobreMomentum{ Esta é a revista momentum! }
 \Participantes{
     {\Large \textbf{Dirección:}}     \\[0.5cm]
@@ -106,8 +104,6 @@ forma seguinte (aproximada)
 }
 \Despedida{ Adeus! }
 \Agradecementos{ Grazas a Todos! }
-\Drive{ https://linkaodrive.com }
-\WhatsApp{ https://link grupo whatsapp }
 
 \begin{document}
 \input{portada.tex}
@@ -119,9 +115,19 @@ forma seguinte (aproximada)
 \input{contraportada.tex}
 \end{document}
 ```
-Os comandos `\Numero, \Data, \ImaxePortada, \Participantes`, e os
-`\definecolor` deben usarse en cada revista e están explicados na [clase da
-revista](./revista.cls)
+
+Os comandos `\Numero, \Data, \ImaxePortada, \ComentarioImaxePortada,
+\SobreMomentum, \Despedida, \Agradecementos, \CorResalte, \CorTextoEnResalte
+\Participantes`, e os `\definecolor` deben usarse en cada revista xa que
+conteñen información específica para cada número. Están explicados na [clase da
+revista](./revista.cls).
+
+Adicionalmente, os macros ` \LinkRepositorio, \Correo, \Drive, \WhatsApp`
+defínense na propia clase da revista porque, en principio, conteñen información
+que non tería sentido cambiar entre os números.
+
+Para mostrar calquera desos valores só hai que prefixar o macro con imprime,
+e.g. `\imprimeCorreo, ou \imprimeNumero`
 
 ### Artigos
 

--- a/contraportada.tex
+++ b/contraportada.tex
@@ -56,7 +56,7 @@
         \hypersetup{urlcolor=black}
         \qrset{height = 4cm}%
         % Que quede para a posteridade que rickrolleei a Celia e a Sebas con este QR
-        \qrcode{\imprimeDrive}
+        \qrcode{\imprimeEdicionsAnteriores}
     \end{center}
 \end{minipage}
 %

--- a/contraportada.tex
+++ b/contraportada.tex
@@ -27,39 +27,13 @@
 \begin{center}
     \begin{minipage}{0.68\linewidth}
     \centering
-    {\Large    Momentum! \\[6mm]
-    Aquí chega a revista por e para estudantes da Facultade de Física USC!
-    Cansos de que o momento lineal e angular guíen as nosas traxectorias, imos
-    escribir unha nova historia; entrevistas, divulgación, filosofía da ciencia e
-    moitos artigos dispares cargamos coa inercia de formar unha nova fiestra para o
-    alumnado. Tes nas túas mans esta oportunidade, deixa que o magnetismo te leve e
-    participa, sé parte deste proxecto: escribe, le, comparte, suxestiona… A
-    revista é real e as túas ideas poden ser máis que imaxinación, non dubides en
-    deixar a túa pegada neste recuncho físico, onde hai física máis aló das aulas.
-    Non dubides unirte ao proxecto!}
+    { \Large \imprimeDespedida }
 \end{minipage} \\[3.15cm]
 
 % Estes textos SEGURO que se cambian en cada revista. Hai que metelo nun macro
 \begin{minipage}{0.75\linewidth}
     \centering
-    {\normalsize  Agradecementos: \\[5mm]
-
-    Dende a dirección da revista, queríamos agradecervos a todos por achegarvos
-a este proxecto. Non hai revista sen lector! Pero, para facela, estivo moita
-xente implicada, que non podemos pasar por alto. \\[5mm]
-
-    Gracias ao noso estimado J. A. Docobo pola súa predisposición e boa vontade
-para participar nun proxecto que aínda non existía, e a Ánxel Costas por
-poñernos en contacto. \\[5mm]
-
-    Gracias a todas as persoas que se interesaron polo proxecto, simplemente
-por intereresarse, aínda que ao final non participaran directamente. \\[5mm]
-
-    E por suposto, tamén temos que mencionar ao equipo decanal da nosa
-facultade, que nos apoiou e motivou dende o primeiro momento, e ofreceu
-financiar a impresión e colaborar con nós nesta primeira edición. Non sería
-posible sen eles! }
-
+    { \imprimeAgradecementos }
     \end{minipage}
 \end{center}
 }
@@ -82,7 +56,7 @@ posible sen eles! }
         \hypersetup{urlcolor=black}
         \qrset{height = 4cm}%
         % Que quede para a posteridade que rickrolleei a Celia e a Sebas con este QR
-        \qrcode{https://drive.google.com/drive/folders/1BSCyGXvnZneKDR1o6fI8nUZ4px71IsLs?usp=sharing}
+        \qrcode{\imprimeDrive}
     \end{center}
 \end{minipage}
 %
@@ -94,7 +68,7 @@ posible sen eles! }
         \hypersetup{urlcolor=black}
         \qrset{height = 4cm}%
         % Que quede para a posteridade que rickrolleei a Celia e a Sebas con este QR
-        \qrcode{https://chat.whatsapp.com/E900g1Bq7QT5ZKeuiIpxTk}
+        \qrcode{\imprimeWhatsApp}
     \end{center}
 \end{minipage}
 %

--- a/indice.tex
+++ b/indice.tex
@@ -38,16 +38,7 @@
             \vfill
             \vspace{2cm}
             {\Huge \color{Resalte!75!black} \textbf{Sobre Momentum}:} \\[1cm]
-Tras uns cantos meses de traballo, por fin podemos dar saída á nova revista
-estudantil \textit{Momentum}, unha revista que busca ser un medio de
-comunicación tanto dentro coma fóra da facultade de física onde expor os
-intereses científicos do estudantado. Cuestións de Divulgación, Actualidade,
-Entrevistas, Historia, Filosofía da Ciencia, Opinión, Programación... Son todos
-temas que teñen cabida dentro deste proxecto. Esta revista está realizada
-integramente polo estudantado da Facultade de Física USC, onde pretendemos ter
-un recuncho de expresión máis aló do estrictamente académico. Fundada no ano
-2025 co obxectivo de persistir na historia, esforzámonos sempre en mellorar.
-Non dubidedes en deixar a vosa pegada!
+            \imprimeSobreMomentum
         \end{minipage}
     \end{minipage}
 \end{minipage}
@@ -79,7 +70,7 @@ Non dubidedes en deixar a vosa pegada!
                 align  = left
             ] at (0.5,0)
             {
-                \textbf{\textcolor{TextoEnResalte}{\href{https://github.com/DAF-USC/revista}{GitHub}}}
+                \textbf{\textcolor{TextoEnResalte}{\href{\imprimeLinkRepositorio}{GitHub}}}
             };
         \endgroup
         \node at (0,-1) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
@@ -88,7 +79,7 @@ Non dubidedes en deixar a vosa pegada!
             align  = left
         ] at (0.5,-1)
         {
-            \footnotesize \textbf{\textcolor{TextoEnResalte}{revistafisicausc@gmail.com} }
+            \footnotesize \textbf{\textcolor{TextoEnResalte}{\imprimeCorreo}}
         };
     \end{tikzpicture} \\[1.7cm]
     %

--- a/indice.tex
+++ b/indice.tex
@@ -62,23 +62,23 @@
     \imprimeParticipantes \\[1.5cm]
     % Links varios
     \begin{tikzpicture}[scale=1.5]
-        \node at (0,0) {\FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \begingroup
-            \hypersetup{urlcolor = TextoEnResalte}
-            \node[
-                anchor = west,
-                align  = left
-            ] at (0.5,0)
-            {
-                \textbf{\textcolor{TextoEnResalte}{\href{\imprimeLinkRepositorio}{GitHub}}}
-            };
-        \node at (0,-1) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        \hypersetup{urlcolor = TextoEnResalte}
+        \node at (0,0) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        \node[
+            anchor = west,
+            align  = left
+        ] at (0.5,0)
+        {
+            \footnotesize \href{mailto:\imprimeCorreo}{\textbf{\imprimeCorreo}}
+        };
+        \node at (0,-1) {\FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \node[
             anchor = west,
             align  = left
         ] at (0.5,-1)
         {
-            \footnotesize \href{mailto:\imprimeCorreo}{\textbf{\imprimeCorreo}}
+            \href{https://github.com/\imprimeLinkRepositorio}{\texttt{\imprimeLinkRepositorio}}
         };
         \endgroup
     \end{tikzpicture} \\[1.7cm]

--- a/indice.tex
+++ b/indice.tex
@@ -72,15 +72,15 @@
             {
                 \textbf{\textcolor{TextoEnResalte}{\href{\imprimeLinkRepositorio}{GitHub}}}
             };
-        \endgroup
         \node at (0,-1) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
         \node[
             anchor = west,
             align  = left
         ] at (0.5,-1)
         {
-            \footnotesize \textbf{\textcolor{TextoEnResalte}{\imprimeCorreo}}
+            \footnotesize \href{mailto:\imprimeCorreo}{\textbf{\imprimeCorreo}}
         };
+        \endgroup
     \end{tikzpicture} \\[1.7cm]
     %
     % Logo da USC

--- a/revista.cls
+++ b/revista.cls
@@ -425,7 +425,7 @@
 % LINK para o REPOSITORIO
 \def\LinkRepositorio#1{\def\@LinkRepositorio{#1}}
 \newcommand{\imprimeLinkRepositorio}{\@LinkRepositorio}
-\LinkRepositorio{https://github.com/DAF-USC/revista}
+\LinkRepositorio{DAF-USC/revista}
 
 % CORREO
 \def\Correo#1{\def\@Correo{#1}}

--- a/revista.cls
+++ b/revista.cls
@@ -441,9 +441,9 @@
 \newcommand{\imprimeAgradecementos}{\@Agradecementos}
 
 % Link para o DRIVE
-\def\Drive#1{\def\@Drive{#1}}
-\newcommand{\imprimeDrive}{\@Drive}
-\Drive{https://drive.google.com/drive/folders/1BSCyGXvnZneKDR1o6fI8nUZ4px71IsLs?usp=sharing}
+\def\EdicionsAnteriores#1{\def\@EdicionsAnteriores{#1}}
+\newcommand{\imprimeEdicionsAnteriores}{\@EdicionsAnteriores}
+\EdicionsAnteriores{https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum}
 
 % Link para o grupo de WHATSAPP
 \def\WhatsApp#1{\def\@WhatsApp{#1}}

--- a/revista.cls
+++ b/revista.cls
@@ -425,10 +425,12 @@
 % LINK para o REPOSITORIO
 \def\LinkRepositorio#1{\def\@LinkRepositorio{#1}}
 \newcommand{\imprimeLinkRepositorio}{\@LinkRepositorio}
+\LinkRepositorio{https://github.com/DAF-USC/revista}
 
 % CORREO
 \def\Correo#1{\def\@Correo{#1}}
 \newcommand{\imprimeCorreo}{\@Correo}
+\Correo{revistafisicausc@gmail.com}
 
 % Texto de DESPEDIDA, na contraportada
 \def\Despedida#1{\def\@Despedida{#1}}
@@ -441,10 +443,12 @@
 % Link para o DRIVE
 \def\Drive#1{\def\@Drive{#1}}
 \newcommand{\imprimeDrive}{\@Drive}
+\Drive{https://drive.google.com/drive/folders/1BSCyGXvnZneKDR1o6fI8nUZ4px71IsLs?usp=sharing}
 
 % Link para o grupo de WHATSAPP
 \def\WhatsApp#1{\def\@WhatsApp{#1}}
 \newcommand{\imprimeWhatsApp}{\@WhatsApp}
+\WhatsApp{https://chat.whatsapp.com/E900g1Bq7QT5ZKeuiIpxTk}
 
 % CORES de resalte. Non fai falta definir estos comandos, pero así podemos usar
 % na revista '\CorResalte{ff0000}' en vez de

--- a/revista.cls
+++ b/revista.cls
@@ -418,6 +418,46 @@
 \def\Participantes#1{\def\@Participantes{#1}}
 \newcommand{\imprimeParticipantes}{\textcolor{TextoEnResalte}{\@Participantes}}
 
+% Texto do indice que presenta a revista
+\def\SobreMomentum#1{\def\@SobreMomentum{#1}}
+\newcommand{\imprimeSobreMomentum}{\@SobreMomentum}
+
+% LINK para o REPOSITORIO
+\def\LinkRepositorio#1{\def\@LinkRepositorio{#1}}
+\newcommand{\imprimeLinkRepositorio}{\@LinkRepositorio}
+
+% CORREO
+\def\Correo#1{\def\@Correo{#1}}
+\newcommand{\imprimeCorreo}{\@Correo}
+
+% Texto de DESPEDIDA, na contraportada
+\def\Despedida#1{\def\@Despedida{#1}}
+\newcommand{\imprimeDespedida}{\@Despedida}
+
+% AGRADECEMENTOS, na contraportada
+\def\Agradecementos#1{\def\@Agradecementos{#1}}
+\newcommand{\imprimeAgradecementos}{\@Agradecementos}
+
+% Link para o DRIVE
+\def\Drive#1{\def\@Drive{#1}}
+\newcommand{\imprimeDrive}{\@Drive}
+
+% Link para o grupo de WHATSAPP
+\def\WhatsApp#1{\def\@WhatsApp{#1}}
+\newcommand{\imprimeWhatsApp}{\@WhatsApp}
+
+% CORES de resalte. Non fai falta definir estos comandos, pero así podemos usar
+% na revista '\CorResalte{ff0000}' en vez de
+% '\definecolor{Resalte}{HTML}{ff0000}'. Algo máis limpo.
+\def\CorResalte#1{\def\@CorResalte{#1}}
+\newcommand{\defineCorResalte}{\definecolor{Resalte}{HTML}{\@CorResalte}}
+\def\CorTextoEnResalte#1{\def\@CorTextoEnResalte{#1}}
+\newcommand{\defineCorTextoEnResalte}{\definecolor{TextoEnResalte}{HTML}{\@CorTextoEnResalte}}
+
+% inicalizo as cores por se acaso
+\definecolor{Resalte}{HTML}{ff0000}
+\definecolor{TextoEnResalte}{HTML}{ffffff}
+
 \makeatother
 % Todos esos comandos teñen a info da revista. Gardase o valor nunha variable,
 % e imprimese no PDF con outro comando diferente. Esto da bastante
@@ -425,14 +465,27 @@
 
 % En cada revista hai que usar estos comandos ao comezo.
 %
-% \Numero{0}
-% \Data{Enero do 1900}
-% \PrimeiroArtigo{Entrevista a Marie Curie}
-% \ImaxePortada{./cern.png}
-% \definecolor{Resalte}{HTML}{ff0000}
-% \definecolor{TextoEnResalte}{HTML}{000000}
-% \ComentarioImaxePortada{ A imaxe da portada e moi bonita}
-% \Participantes{ Rocio, \\ Arturo }%
+% \Numero{001}
+% \Data{Xaneiro do 1900}
+% \ImaxePortada{./revistas/001/imaxes/cern.png}
+% \ComentarioImaxePortada{ Imaxe da portada }
+% \CorResalte{ff0000} % cores especificos de cada revista, con codigos HTML hex
+% \CorTextoEnResalte{000000}
+% \LinkRepositorio{ guthib.com }
+% \Correo{ correo@correo.correo }
+% \SobreMomentum{ Esta é a revista momentum! }
+% \Participantes{
+%     {\Large \textbf{Dirección:}}     \\[0.5cm]
+%         Carl Sagan                   \\[0.2cm]
+%     {\Large \textbf{Edición}}        \\[0.5cm]
+%         Albert Einstein              \\[0.2cm]
+%     {\Large \textbf{Diseño de Logo}} \\[0.5cm]
+%         Dirac                        \\[0.2cm]
+% }
+% \Despedida{ Adeus! }
+% \Agradecementos{ Grazas a Todos! }
+% \Drive{ https://linkaodrive.com }
+% \WhatsApp{ https://link grupo whatsapp }
 
 % Os comandos anteriores definen as variables. Pa mostralas no pdf hai que usar:
 %
@@ -440,10 +493,15 @@
 % \imprimeNumero          Numero da revista
 % \imprimeData            Data de creacion
 % \imprimeImaxePortada    ruta para a imaxe de portada, debe especificarse en cada revista
-% \imprimePrimeiroArtigo  %
-% \imprimePrimeiroArtigo  % Nomes dos artigos principais.
-% \imprimeTerceiroArtigo  %
 % \color{Resalte}         Para colorear cousas ca cor específica de cada revista
+% \color{TextoEnResalte}  Para colorear texto que esté sobre fondo ca cor do resalte
+% \imprimeParticipantes   Nomes dos participantes
+% \imprimeSobreMomentum
+% \imprimeLinkRepositorio
+% \imprimeDespedida
+% \imprimeAgradecementos
+% \imprimeDrive
+% \imprimeWhatsApp
 
 % :FACER: remirar estos conteos...
 % \pagenumbering{arabic}\setcounter{page}{1}

--- a/revistas/001/revista_001.tex
+++ b/revistas/001/revista_001.tex
@@ -4,6 +4,22 @@
 \Data{Abril 2025}
 \ImaxePortada{./revistas/001/imaxes/pedra.jpg}
 \ComentarioImaxePortada{\textbf{1981: Primeira pedra da facultade de física.}}
+\CorResalte{ff0000}
+\CorTextoEnResalte{ffffff}
+\LinkRepositorio{https://github.com/DAF-USC/revista}
+\Correo{revistafisicausc@gmail.com}
+\SobreMomentum{
+    Tras uns cantos meses de traballo, por fin podemos dar saída á nova revista
+    estudantil \textit{Momentum}, unha revista que busca ser un medio de
+    comunicación tanto dentro coma fóra da facultade de física onde expor os
+    intereses científicos do estudantado. Cuestións de Divulgación, Actualidade,
+    Entrevistas, Historia, Filosofía da Ciencia, Opinión, Programación... Son todos
+    temas que teñen cabida dentro deste proxecto. Esta revista está realizada
+    integramente polo estudantado da Facultade de Física USC, onde pretendemos ter
+    un recuncho de expresión máis aló do estrictamente académico. Fundada no ano
+    2025 co obxectivo de persistir na historia, esforzámonos sempre en mellorar.
+    Non dubidedes en deixar a vosa pegada!
+}
 \Participantes{%
     {\Large \textbf{Dirección}}     \\[0.5cm] %
         Álvaro Pallas Otero          \\[0.2cm] %
@@ -21,6 +37,35 @@
     {\Large \textbf{Deseño de Logo}} \\[0.5cm]%
         Ana Díaz Caride              \\[0.2cm]%
 }
+\Despedida{
+    Momentum! \\[6mm]
+    Aquí chega a revista por e para estudantes da Facultade de Física USC!
+    Cansos de que o momento lineal e angular guíen as nosas traxectorias, imos
+    escribir unha nova historia; entrevistas, divulgación, filosofía da ciencia e
+    moitos artigos dispares cargamos coa inercia de formar unha nova fiestra para o
+    alumnado. Tes nas túas mans esta oportunidade, deixa que o magnetismo te leve e
+    participa, sé parte deste proxecto: escribe, le, comparte, suxestiona… A
+    revista é real e as túas ideas poden ser máis que imaxinación, non dubides en
+    deixar a túa pegada neste recuncho físico, onde hai física máis aló das aulas.
+    Non dubides unirte ao proxecto!
+}
+\Agradecementos{
+    Agradecementos: \\[5mm]
+    Dende a dirección da revista, queríamos agradecervos a todos por achegarvos
+    a este proxecto. Non hai revista sen lector! Pero, para facela, estivo moita
+    xente implicada, que non podemos pasar por alto. \\[5mm]
+    Gracias ao noso estimado J. A. Docobo pola súa predisposición e boa vontade
+    para participar nun proxecto que aínda non existía, e a Ánxel Costas por
+    poñernos en contacto. \\[5mm]
+    Gracias a todas as persoas que se interesaron polo proxecto, simplemente
+    por intereresarse, aínda que ao final non participaran directamente. \\[5mm]
+    E por suposto, tamén temos que mencionar ao equipo decanal da nosa
+    facultade, que nos apoiou e motivou dende o primeiro momento, e ofreceu
+    financiar a impresión e colaborar con nós nesta primeira edición. Non sería
+    posible sen eles!
+}
+\Drive{https://drive.google.com/drive/folders/1BSCyGXvnZneKDR1o6fI8nUZ4px71IsLs?usp=sharing}
+\WhatsApp{https://chat.whatsapp.com/E900g1Bq7QT5ZKeuiIpxTk}
 
 \begin{document}
 \input{portada.tex}

--- a/revistas/001/revista_001.tex
+++ b/revistas/001/revista_001.tex
@@ -6,8 +6,6 @@
 \ComentarioImaxePortada{\textbf{1981: Primeira pedra da facultade de física.}}
 \CorResalte{ff0000}
 \CorTextoEnResalte{ffffff}
-\LinkRepositorio{https://github.com/DAF-USC/revista}
-\Correo{revistafisicausc@gmail.com}
 \SobreMomentum{
     Tras uns cantos meses de traballo, por fin podemos dar saída á nova revista
     estudantil \textit{Momentum}, unha revista que busca ser un medio de
@@ -64,8 +62,6 @@
     financiar a impresión e colaborar con nós nesta primeira edición. Non sería
     posible sen eles!
 }
-\Drive{https://drive.google.com/drive/folders/1BSCyGXvnZneKDR1o6fI8nUZ4px71IsLs?usp=sharing}
-\WhatsApp{https://chat.whatsapp.com/E900g1Bq7QT5ZKeuiIpxTk}
 
 \begin{document}
 \input{portada.tex}


### PR DESCRIPTION
Agora a revista debería ser máis modular. Todos os links e textos da portada, índice e contraportada contrólanse dende o arquivo da revista correspondente, e.g. 'revistas/001/revista_001.tex'.