### PR TITLE
Erro no comando para a cor do texto con fondo resaltado 

### DIFF
--- a/revista.cls
+++ b/revista.cls
@@ -465,7 +465,7 @@
     \hypersetup{linkcolor = {Resalte!55!black}}%
 }%
 
-\newcommand{\defineCorTextoEnResalte}[1]{
+\newcommand{\CorTextoEnResalte}[1]{
     \definecolor{TextoEnResalte}{HTML}{#1}
 }
 


### PR DESCRIPTION
Puxera mal o nome do macro, por eso a revista non iba