### PR TITLE
Máis logos da facultade e vicerreitoría

### DIFF
--- a/logos/fisica-branco-negro.pdf
+++ b/logos/fisica-branco-negro.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7c2f74f4eb795860839cafb4f9d419fa6954f74f615462f426e72573f654142
+size 27062

--- a/logos/fisica-negativo-azul.pdf
+++ b/logos/fisica-negativo-azul.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24905af74919a85de099f603d3a9af3f86d4f70b252d1447568b3b156dc61e8c
+size 27468

--- a/logos/fisica-negativo-escuro.pdf
+++ b/logos/fisica-negativo-escuro.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:173ad1a0c289aef1a26c5fa113c512366808bcd8ee4a1c1ba32f1435370f55bc
+size 11005

--- a/logos/fisica-normal.pdf
+++ b/logos/fisica-normal.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2a9fb3255fc9f5659ae5b3e18d004ae10de4cc6e49c5dba795d6e5577ebf636
+size 27100

--- a/logos/usc-fisica.png
+++ b/logos/usc-fisica.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2456ee30fda44c1c6a3b07b487ee5c372e0f7b78d5593477b0e3c8a738b7814b
-size 37261

--- a/logos/usc-invertido.png
+++ b/logos/usc-invertido.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ec4a3e0d4ead153bd474ed12b05f78ae9b2aaebc2aa3d1c8aec2226717c0f04
-size 77939

--- a/logos/vicerreitoria-negativo-escuro.pdf
+++ b/logos/vicerreitoria-negativo-escuro.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ae8bfdd94277cc7274635ad599f3831b23226376b435d160f5139eb252da40e
+size 30058


### PR DESCRIPTION
Cambio no formato dos logos da facultade, pasan a formato `.pdf`, e engade o da vicerreitoría invertido. Ocupan máis ben pouco espazo e así xa os temos para a posterioridade.