### PR TITLE
Pasamos de usar biblatex -> citation-style-language

### DIFF
--- a/american-physics-society.csl
+++ b/american-physics-society.csl
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>American Physical Society</title>
+    <title-short>APS</title-short>
+    <id>http://www.zotero.org/styles/american-physics-society</id>
+    <link href="http://www.zotero.org/styles/american-physics-society" rel="self"/>
+    <link href="http://www.zotero.org/styles/american-institute-of-physics" rel="template"/>
+    <link href="https://journals.aps.org/prl/authors#techformat" rel="documentation"/>
+    <author>
+      <name>Richard Karnesky</name>
+      <email>karnesky+zotero@gmail.com</email>
+      <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+    </author>
+    <author>
+      <name>Brenton M. Wiernik</name>
+    </author>
+    <contributor>
+      <name>Anna C. Véron</name>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="physics"/>
+    <summary>Common style use by APS publications.</summary>
+    <updated>2025-02-10T03:11:08+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" et-al-min="11" et-al-use-first="1" initialize-with=". " delimiter=", "/>
+      <label form="long" prefix=", " suffix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="verb" suffix=" "/>
+      <name delimiter=", " initialize-with=". " and="text"/>
+    </names>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group prefix="(" suffix=")" delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place" text-case="title"/>
+      <text macro="year-date"/>
+    </group>
+  </macro>
+  <macro name="edition-volume">
+    <group delimiter=", ">
+      <choose>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <text term="edition" form="short"/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition"/>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <label variable="volume" form="short" text-case="capitalize-first"/>
+        <text variable="volume"/>
+      </group>
+    </group>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," prefix="&#160;[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <!-- Reference for book, chapter, report layouts: https://doi.org/10.1103/PhysRevX.10.011010 -->
+    <!-- Reference for arXiv: https://doi.org/10.1103/PhysRevX.10.011004 -->
+    <layout suffix=".">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" suffix=", "/>
+      <choose>
+        <if type="bill book figure graphic legal_case legislation map motion_picture song treaty" match="any">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text variable="title" text-case="title" font-style="italic"/>
+              <text macro="edition-volume"/>
+            </group>
+            <text macro="publisher"/>
+          </group>
+        </if>
+        <else-if type="broadcast chapter entry entry-dictionary entry-encyclopedia paper-conference" match="any">
+          <group delimiter=", ">
+            <text variable="title" text-case="title" font-style="italic"/>
+            <group delimiter=" ">
+              <text term="in"/>
+              <group delimiter=", ">
+                <text variable="container-title" text-case="title" font-style="italic"/>
+                <text macro="editor"/>
+                <text macro="edition-volume"/>
+              </group>
+              <group delimiter=", ">
+                <text macro="publisher"/>
+                <group delimiter=" ">
+                  <label variable="page" form="short"/>
+                  <text variable="page"/>
+                </group>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=", ">
+            <text variable="title" text-case="title" font-style="italic"/>
+            <group delimiter=" ">
+              <text variable="number"/>
+              <text macro="day-date" prefix="(" suffix=")"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="thesis report" match="any">
+          <group delimiter=", ">
+            <text variable="title" text-case="title"/>
+            <group delimiter=" ">
+              <text variable="genre"/>
+              <group delimiter=" ">
+                <text term="issue" form="short" text-case="capitalize-first"/>
+                <text variable="number"/>
+              </group>
+            </group>
+            <text variable="publisher"/>
+            <text macro="year-date"/>
+          </group>
+        </else-if>
+        <else-if type="article" match="any">
+          <group delimiter=", ">
+            <text variable="title" text-case="title" font-style="italic"/>
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="dataset interview manuscript pamphlet personal_communication post post-weblog speech webpage" match="any">
+          <!-- unpublished materials; guidelines call for 'enough information to be retrievable' -->
+          <!-- Based on arXiv format -->
+          <group delimiter=", ">
+            <text variable="title" text-case="title" font-style="italic"/>
+            <choose>
+              <if variable="DOI">
+                <text variable="DOI" prefix="https://doi.org/"/>
+              </if>
+              <else-if variable="URL">
+                <text variable="URL"/>
+              </else-if>
+              <else>
+                <text value="(unpublished)"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <!--article-journal article-magazine article-newspaper review review-book-->
+          <group delimiter=", ">
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short" text-case="title"/>
+              <group delimiter=", ">
+                <text variable="volume" font-weight="bold"/>
+                <group delimiter=" ">
+                  <choose>
+                    <if variable="number">
+                      <text variable="number"/>
+                    </if>
+                    <else>
+                      <text variable="page-first" form="short"/>
+                    </else>
+                  </choose>
+                  <text macro="year-date" prefix="(" suffix=")"/>
+                </group>
+              </group>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/revista.cls
+++ b/revista.cls
@@ -66,12 +66,15 @@
 % 'csquotes'
 \RequirePackage{csquotes}
 
-% :FACER: non temos un estilo concreto para a bibliografía
-% Bibliografia
+% BIBLIOGRAFIA. Pasamos a usar o método máis comodo, xeral e rápido: CSL
+% https://www.ctan.org/pkg/citation-style-language
+% https://github.com/citation-style-language/styles
+% https://www.zotero.org/styles
 \RequirePackage[
-    % style  = alphabetic,
-    natbib = true,
-]{biblatex}
+    style       = american-physics-society,
+    % locale      = gl, % non furrula aquí, pero cargase solo con babel galician
+    ref-section = section
+]{citation-style-language}
 \addbibresource{bibliografia.bib}
 
 % Cores. En cada artigo usamos \definecolor{}{} pa coller o que queremos

--- a/revistas/002/artigo_DARKO.tex
+++ b/revistas/002/artigo_DARKO.tex
@@ -4,7 +4,6 @@
 {divulgacion}%
 {Breve disertación sobre a ciencia no filme \textit{Donnie Darko}.}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -132,4 +131,3 @@ disto a un filme tan claramente feito para o público estadounidense xeral.
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_DZHANIBEKOV.tex
+++ b/revistas/002/artigo_DZHANIBEKOV.tex
@@ -4,7 +4,6 @@
 {divulgacion}%
 {Un fenómeno físico que conecta aos mongois, Euler e... a fin do Mundo?}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -134,4 +133,3 @@ considerablemente o peso e o combustible necesario para estas misións
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_ENTREVISTA_ANA.tex
+++ b/revistas/002/artigo_ENTREVISTA_ANA.tex
@@ -4,7 +4,6 @@
 {entrevistas}%
 {Camiños na astrofísica, desafíos e horizontes futuros.}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 \subsection*{Biografía}
@@ -225,4 +224,3 @@ as situacións, todas, se pode obter sempre información útil para o presente e
 futuro. Ou, incluso e posiblemente, para reinterpretar o pasado.
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_HOOKE.tex
+++ b/revistas/002/artigo_HOOKE.tex
@@ -4,7 +4,6 @@
 {historia}%
 {Sobre como se pode pasar de ser a gran figura da túa época a ser case esquecido.}
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -113,4 +112,3 @@ Leonardo da Vinci inglés''.
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_HeB.tex
+++ b/revistas/002/artigo_HeB.tex
@@ -5,7 +5,6 @@
 {As vidas dun beisbolista e dun dos pais da Física Cuántica, cruzadas por unha
 historia de espías e o proxecto atómico da Alemaña nazi.}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 \subsection*{Heisenberg e o \textit{proxecto Uranio}}
@@ -149,4 +148,3 @@ esperado son capaces de cambiar o rumbo da historia.
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_LEEUWEN.tex
+++ b/revistas/002/artigo_LEEUWEN.tex
@@ -5,7 +5,6 @@
 {Da imposibilidade clásica do magnetismo.}%
 
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -172,4 +171,3 @@ Nanomagnetismo e Nanotecnoloxía desta facultade.
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_MATERIA_ESCURA.tex
+++ b/revistas/002/artigo_MATERIA_ESCURA.tex
@@ -5,7 +5,6 @@
 {O descubrimento da maior parte da materia do universo e o enigma da súa composición.}%
 
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -143,4 +142,3 @@ enigma
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_MERINO.tex
+++ b/revistas/002/artigo_MERINO.tex
@@ -5,7 +5,6 @@
 {Dpto. Física de Partículas - Facultade de Física, IGFAE\\
 Universidade de Santiago de Compostela}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 \subsection*{En homenaxe a Alexei B. Kaidalov}
@@ -229,4 +228,3 @@ número de \textit{Momentum} teña continuación en moitos máis números no fut
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_PASATEMPOS.tex
+++ b/revistas/002/artigo_PASATEMPOS.tex
@@ -4,7 +4,6 @@
 {pasatempos}%
 {}%
 
-\begin{refsection}
 \vspace*{-6mm}
 \section*{\textcolor{Resalte}{Encrucillado } {\normalfont \itshape Luis Arcas Morcillo}}%
 
@@ -115,7 +114,6 @@ recorrendo á teoría de grupos.
 \end{center}
 
 \end{multicols}
-\end{refsection}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/revistas/002/artigo_SCHRODINGER.tex
+++ b/revistas/002/artigo_SCHRODINGER.tex
@@ -4,7 +4,6 @@
 {divulgacion}%
 {Unha bela relación entre a mecánica clásica, a óptica e a cuántica.}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 
@@ -256,4 +255,3 @@ $\Psi$ unha interpretación aínda.
 \printbibliography
 
 \end{multicols}
-\end{refsection}

--- a/revistas/002/artigo_VOYAGER.tex
+++ b/revistas/002/artigo_VOYAGER.tex
@@ -4,7 +4,6 @@
 {historia}%
 {De como a Voyager 1 partiu dende a Terra ata o espazo profundo.}%
 
-\begin{refsection}
 \begin{multicols}{2}
 
 \subsection*{\textit{Na beira do océano cósmico}.}
@@ -211,4 +210,3 @@ voando.}>>
 \printbibliography
 
 \end{multicols}
-\end{refsection}


### PR DESCRIPTION
- Miles de estilos en https://github.com/citation-style-language/styles
- Elimina a dependencia de `biber`
- Menos fricción con Babel
- Necesaria unha pasada menos do compilador (4 -> 3)
- Menos tempo de compilacion. biblatex:35s, csl:27s
- Fai falta descargar un arquivo *.csl como modelo, incluese american-physical-society.cls
- Podemos quitar as `\refsection` dos artigos usando a opcion `ref-section = section`