### PR TITLE
Regra de make para crear o .zip do artigo simplificado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 *.ilg
 *.ind
 
+# arquivos comprimidos
+*.zip
+
 # varios
 tex.err
 tex.err.bak

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ limpa:
 
 # accion para empaquetar os arquivos necesarios para o artigo simplificado
 modelo:
-	zip -r modelo.zip fontes/ artigo_simplificado.tex revista.cls latexmkrc
+	zip -r modelo.zip fontes/ artigo_simplificado.tex revista.cls latexmkrc *.csl
 
 .PHONY: rula limpa

--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,8 @@ rula: revistas/$(numero)/revista_$(numero).tex
 limpa:
 	rm -rf .pdf/* .aux/* # pra limpar os diretorios
 
+# accion para empaquetar os arquivos necesarios para o artigo simplificado
+modelo:
+	zip -r modelo.zip fontes/ artigo_simplificado.tex revista.cls
+
 .PHONY: rula limpa

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ limpa:
 
 # accion para empaquetar os arquivos necesarios para o artigo simplificado
 modelo:
-	zip -r modelo.zip fontes/ artigo_simplificado.tex revista.cls
+	zip -r modelo.zip fontes/ artigo_simplificado.tex revista.cls latexmkrc
 
 .PHONY: rula limpa


### PR DESCRIPTION
Temos unha versión simplificada da revista, `artigo_simplificado.tex`,
que usa a mesma clase da revista completa, e tamén as mesmas fontes.
Este `modelo` máis simple compartímolo co resto do grupo de edición.
Dada a cantidade de cambios que soemos facer, penso que é comodo engadir
unha regra na `makefile` para poder xuntar os arquivos necesarios para
dito modelo e así compartilos.

Só hai que escribir:
make modelo

Usa o programa `zip` para comprimir os arquivos, tal vez se pode
facer algún chequeo e algún fallback (e.g. 7zip)

Tamén se cambia o .gitignore para evitar problemas a maiores cos
arquivos comprimidos e git