### PR TITLE
[IDEA] Usar gitinfo2 para mostrar o hash de git

### DIFF
--- a/indice.tex
+++ b/indice.tex
@@ -84,6 +84,16 @@
         % {
         %     \href{https://github.com/\imprimeLinkRepositorio}{\texttt{\imprimeLinkRepositorio}}
         % };
+        % Version do proxecto dende o que compilamos a revista
+        \node at (0,-1) {%
+            \FonteSimbolos\fontsize{20pt}{0pt}\selectfont%
+            \textcolor{TextoEnResalte}  %
+        };%
+        \node[
+            anchor = west,
+            align  = left
+        ] at (0.5,-1)
+        { \textcolor{TextoEnResalte}{\texttt{\gitAbbrevHash}} }; % <- hash da contribucion actual, grazas a 'gitinfo2'
         \endgroup
     \end{tikzpicture} \\[1.7cm]
     %

--- a/revista.cls
+++ b/revista.cls
@@ -135,6 +135,15 @@
 % info gárdase no *.log, de cara ao final logo dunha liña que pon *File List*
 % \listfiles
 
+% Para ter algo máis de info, engadimos ao PDF o numero ca contribucion con
+% gitinfo2. O que fai o paquete é engadir un 'git hook' ao proxecto, o cal xera
+% un arquivo (.git/gitHeadInfo.gin) con info sobre a versión (rama, hash da
+% HEAD, etc.) o cal logo se le con latex e se pode acceder con varios comandos
+% como.
+\RequirePackage[
+    missing = {NoGit}, % qué mostrar se non tamos nun repositorio de git
+]{gitinfo2}
+
 % Para colocar cousas en 2 (ou 3 ou 4...) columnas. É preferible á opcion da
 % clase 'twocols' porque esa da moitísimos problemas no caso de que queiramos
 % ter partes que non teñan 2 columnas. Aparte de que se pode configurar menos


### PR DESCRIPTION
Ao usar git para manexar as distintas versions da revista, pensei que tiña sentido engadir o hash da contribución *concreta* que se usou para compilala. Usase o paquete 'gitinfo2' co comando `\gitAbbrevHash` para engadir o hash no indice.

OLLO: hai que fedellar nos hooks de git para que esto funcione. Non sei se merece a pena a molestia. Ademáis, queremos mostralo sempre? No caso de que alguén compile na casa fora dun repo de git, non lle vai mostrar o hash (poñeralle NoGit).

Véxase 'setup and tailoring', https://ctan.javinator9889.com/macros/latex/contrib/gitinfo2/gitinfo2.pdf