### PR TITLE
`\textcolor` ten dous argumentos con parenteses recurvos

### DIFF
--- a/indice.tex
+++ b/indice.tex
@@ -67,7 +67,7 @@
     \begin{tikzpicture}[scale=1.5]
         \begingroup
         \hypersetup{urlcolor = TextoEnResalte}
-        \node at (0,0) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        \node at (0,0) { \FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}{  }};
         \node[
             anchor = west,
             align  = left
@@ -76,7 +76,7 @@
             \footnotesize \href{mailto:\imprimeCorreo}{\textbf{\imprimeCorreo}}
         };
         % Comentado mentras pensamos se metemos a revista na DAF ou no
-        % \node at (0,-1) {\FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}  };
+        % \node at (0,-1) {\FonteSimbolos\fontsize{20pt}{0pt}\selectfont \textcolor{TextoEnResalte}{  }};
         % \node[
         %     anchor = west,
         %     align  = left


### PR DESCRIPTION
Por algun motivo non lle puxeramos o segundo par de {}. Non daba erro porque xusto ocurría en casos onde só tiñamos un caracter despois (e.g. o simbolo do mail)