### PR TITLE
Macro para engadir titulos e autores dos pasatempos

### DIFF
--- a/revista.cls
+++ b/revista.cls
@@ -506,6 +506,28 @@
 \definecolor{Resalte}{HTML}{ff0000}
 \definecolor{TextoEnResalte}{HTML}{ffffff}
 
+% Un macro para os pasatempos, para facilitarnos algo a vida
+%
+% #1 (entre corchetes [...]) texto opcional á dereita
+% #2 TITULO. Primeiro argumento entre parenteses recurvos {...}
+% #3 AUTOR. Segundo argumento entre parenteses recurvos {...}
+%
+% Exemplos:
+% \Pasatempo[fontes: wikipedia]{Encrucillado}{Manolito}
+% \Pasatempo{Integral dificil}{Alvaro}
+%
+% :FACER: non me convence meter todo dentro do argumendo de \section, pero
+% funciona... asique todo ben
+\NewDocumentCommand\Pasatempo{ o m m }{%
+    \section*{%
+        \textcolor{Resalte}{#2 }% AUTOR
+        {\normalfont \itshape #3}% TITULO DO PASATEMPO
+        \IfNoValueTF{#1}%
+            {}%
+            {\hfill {\small #1}}%
+    }%
+}
+
 \makeatother
 % Todos esos comandos teñen a info da revista. Gardase o valor nunha variable,
 % e imprimese no PDF con outro comando diferente. Esto da bastante

--- a/revistas/002/artigo_PASATEMPOS.tex
+++ b/revistas/002/artigo_PASATEMPOS.tex
@@ -5,7 +5,7 @@
 {}%
 
 \vspace*{-6mm}
-\Pasatempo{Luis Arcas Morcillo}{Encrucillado}
+\Pasatempo{Encrucillado}{Luis Arcas Morcillo}
 
 % Descomentar para entrar no modo solución
 % No modo solución todos os puzzles saen resoltos
@@ -72,7 +72,7 @@ PNHFN PREA PEVFGNY PHNAGB SNFRF SÍFVPN TEVSSVGUF VAREPVN VAGRAFVQNQR YHM
 ZBZRAGB ARJGBA BFPVYNQBERF CBVFFBA CÉAQHYB HZN IRAHF IBYSENZVB MRRZNA ÉGRE
 \end{center}
 
-\Pasatempo[Fonte: @Ankxparch en Instagram]{Álvaro Pallas Otero}{Exercicios para relaxarnos}
+\Pasatempo[Fonte: @Ankxparch en Instagram]{Exercicios para relaxarnos}{Álvaro Pallas Otero}
 
 \begin{multicols}{2}
 \begin{gather*}

--- a/revistas/002/artigo_PASATEMPOS.tex
+++ b/revistas/002/artigo_PASATEMPOS.tex
@@ -5,7 +5,7 @@
 {}%
 
 \vspace*{-6mm}
-\section*{\textcolor{Resalte}{Encrucillado } {\normalfont \itshape Luis Arcas Morcillo}}%
+\Pasatempo{Luis Arcas Morcillo}{Encrucillado}
 
 % Descomentar para entrar no modo solución
 % No modo solución todos os puzzles saen resoltos
@@ -72,7 +72,7 @@ PNHFN PREA PEVFGNY PHNAGB SNFRF SÍFVPN TEVSSVGUF VAREPVN VAGRAFVQNQR YHM
 ZBZRAGB ARJGBA BFPVYNQBERF CBVFFBA CÉAQHYB HZN IRAHF IBYSENZVB MRRZNA ÉGRE
 \end{center}
 
-\section*{\textcolor{Resalte}{Exercicios para relaxarnos}  {\normalfont \itshape Álvaro Pallas Otero}   \hfill     {\small (Fonte: @Ankxparch en Instagram)}}%
+\Pasatempo[Fonte: @Ankxparch en Instagram]{Álvaro Pallas Otero}{Exercicios para relaxarnos}
 
 \begin{multicols}{2}
 \begin{gather*}
@@ -87,7 +87,7 @@ ZBZRAGB ARJGBA BFPVYNQBERF CBVFFBA CÉAQHYB HZN IRAHF IBYSENZVB MRRZNA ÉGRE
 
 \newpage
 
-\section*{\textcolor{Resalte}{Colgando cadros} {\normalfont \itshape Víctor Díaz Díaz}}%
+\Pasatempo{Colgando Cadros}{Víctor Díaz Díaz}
 
 \begin{multicols}{2}
 
@@ -121,7 +121,7 @@ grupos.
 %jjjjjjj
 % QUE NADIE BORRE ESTO, QUE QUEDE PARA A POSTERIDADE !!
 % POR FAVOR PEDÍMLO TODOS
-\section*{\textcolor{Resalte}{Física ou Fortuna \#1: Vaime chover na praia?} {\normalfont \itshape Adrián Vázquez Velasco}}%
+\Pasatempo{Física ou Fortuna \#1: Vaime chover na praia?}{Adrián Vázquez Velasco}
 
 \begin{multicols}{2}
 


### PR DESCRIPTION
Implementada a idea orixinal de Andrea. Agora podemos facer simplemente \Pasatempo{Titulo}{Autor}, e opcionalmente \Pasatempo[texto extra]{Titulo}{Autor}. Aforramos texto nos artigos e aseguramonos de que todos os titulos se vexa iguais