### PR TITLE
Creado novo directorio para gardar trebelladas

### DIFF
--- a/trebellos/README.md
+++ b/trebellos/README.md
@@ -1,0 +1,7 @@
+## Ferramentas de utilidade varia
+
+Aquí pretendemos gardar pequenos programas, scripts, ferramentas, etc. que nos poden facer a vida algo máis fácil.
+
+`instalador_texlive.sh` é un programiña para descargar a distribución de TeXLive completa. Son só os comandos de https://tug.org/texlive/quickinstall.html copiados e pouco máis. TeXLive é a única distribución de La/TeX usada oficialmente polo grupo de edición da revista.
+
+`diccionario_galego.sh` permite xerar uns arquivos `.dic` e `.aff` a partir do repositorio do proxecto trasno https://gitlab.com/trasno/hunspell-gl Ditos arquivos poden usarse con correctores ortográficos (en concreto, Hunspell) para corrixir a ortografía. É posible que no futuro se automatice (polo menos parcialmente) a corrección ortográfica (inda que non prometemos nada). Polo de agora non lle damos uso a esto

--- a/trebellos/diccionario_galego.sh
+++ b/trebellos/diccionario_galego.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+# Este é un pequeno programa para xerar arquivos *.dic e *.aff dende o proxecto
+# trasno. Os comandos son sacados do repositorio oficial de transo:
+# https://gitlab.com/trasno/hunspell-gl , con mínimas modificacións e comentarios
+
+# Primeiro creamos un directorio temporal onde clonar o proxecto completo
+mkdir hunspell_temp
+
+# E metémonos nel
+cd hunspell_temp || exit
+
+# Clonamos o repositorio
+git clone https://gitlab.com/trasno/hunspell-gl
+
+# Metémonos no repositorio
+cd husnpell-gl || exit
+
+# E comezamos a montar o proxecto. Fai falta usar python para xerar os arquivos
+# *.dic e *.aff, creando un entorno virtual e instalando os paquetes 'wheel',
+# 'PyICU' e 'SCons'
+python3 -m venv venv && source venv/bin/activate && pip install wheel PyICU SCons
+
+# Esta variable é pa escoller que fontes usar para os dicionarios
+TODO=$(ls src | grep -v / | xargs echo | sed 's/ /,/g')
+
+# Usase o programa Scons para construír todo (análogo a unha Makefile)
+scons -c && scons metadata=strip aff=$TODO dic=$TODO rep=$TODO
+
+# desactivamos o entorno virtual
+deactivate
+
+# No directorio 'build' deberíamos ter un arquivo *.dic e *.aff
+cd build || exit

--- a/trebellos/instalador_texlive.sh
+++ b/trebellos/instalador_texlive.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+# Pequeno programa para instalar a versión completa de TeXLive en Linux. Todos
+# os comandos veñen de https://tug.org/texlive/quickinstall.html só cun par de
+# pequenas modificacións e comentarios. Lede ven o que fai antes de usalo. Pode
+# levar varias horas rematar.
+#
+# Executar con:
+# source instalador_texlive.sh
+
+# Creamos un directorio temporal. Máis adiante poderemos borralo sen problema
+mkdir texlive_temp
+
+# Metémonos en dito directorio
+cd texlive_temp
+
+# Descargamos a ultima versión de TeXLive. Necesario ter instalado 'wget'. Esto
+# descarga o arquivo install-tl-unx.tar.gz no directorio actual (o temporal).
+# Esto é un arquivo comprimido cun script de Perl que é o propio instalador
+wget https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+
+# Descomprimimos o arquivo
+zcat < install-tl-unx.tar.gz | tar xf - # Importante o '-' final
+
+# Borramos o arquivo comprimido, xa non fai falta
+rm install-tl-unx.tar.gz
+
+# Logo de descomprimir, metemonos no novo directorio
+cd install-tl-* || echo "algo foi mal"
+
+# Executamos o script de Perl. Esto pode levar horas. Uso 'sudo' para ter
+# privilexios, pero dependendo do sistema pode non facer falta. Instala as
+# cousas por defecto en /usr/local/texlive/20**/  Importante engadir a ruta
+# /usr/local/texlive/20**/bin/plataforma á variable de entorno $PATH (podedes
+# facelo na vosa .bashrc)
+sudo perl ./install-tl --no-interaction


### PR DESCRIPTION
A medida que vai crecendo o repositorio vánsenos ocorrendo máis e máis ideas para facer. Pensamos que estaría ben crear un directorio aparte onde gardar programas 'auxiliares' ou 'ferramentas' que, inda que non contribúen directamente á revista, poden resultar útiles.

Inclúese:
- Programa para instalar TeXLive completo en Linux
- Programa para crear arquivos .dic e .aff en galego

Potencialmente, poderíanse meter máis trangalladas no novo directorio. Por exemplo, algún programa de corrección ortográfica (usando Hunspell e os arquivos *.dic e *.aff antes mencionados), programas para automatizar algo (facer parte do proceso maquetación, tal vez?). Tamén podemos usalo de 'caixón' e gardar cousas no caso de ter un repo moi grande (e.g. os .csl, logos, ??). Está por ver.