### PR TITLE
Polyglossia, captions en sans-serif, macro citas

### DIFF
--- a/fontes/LatinModern/lmsans10-bold.otf
+++ b/fontes/LatinModern/lmsans10-bold.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f5c6482313cdb8db5a789b8916a07630cf0ab7e57977cac278d4137b78c3c17
+size 103800

--- a/indice.tex
+++ b/indice.tex
@@ -38,7 +38,7 @@
         \vfill
         \begin{minipage}[t]{0.9\textwidth}
             \vfill
-            \vspace{2cm}
+%            \vspace{2cm}
             % :FACER: o SobreMomentum non colle, deberíamos quitalo de todo
             %{\Huge \color{Resalte!75!black} \textbf{Sobre Momentum}:} \\[1cm]
             %\imprimeSobreMomentum

--- a/revista.cls
+++ b/revista.cls
@@ -10,7 +10,7 @@
 % os comentarios con :FACER: están para usar con ferramentas como grep
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{revista}[2025/05/06 Clase para a revista de Fisica USC]
+\ProvidesClass{revista}[2025/05/31 Clase para a revista de Fisica USC]
 
 \LoadClass[11pt,a4paper,twoside]{extarticle}
 
@@ -190,7 +190,6 @@
 % sola línea (por defecto, lo hace aunque hayas pedido justificación).
 % :FACER: tal vez podemos customizar algo mais as captions (sans serif?)
 \RequirePackage{caption}
-\renewcommand{\bfdefault}{bx}
 \captionsetup{
     font            = footnotesize,
     justification   = justified,

--- a/revista.cls
+++ b/revista.cls
@@ -61,9 +61,9 @@
 ]{SymbolsNerdFontMono}
 
 % Usar galego (como debe ser)
-\RequirePackage[galician]{babel}
-% Usar babel pode fastidiar as citas con biblatex, asique hai que usar
-% 'csquotes'
+\RequirePackage{polyglossia}
+\setmainlanguage{galician}
+% Para garantizar que as citas funcionen ben con BibLaTeX:
 \RequirePackage{csquotes}
 
 % BIBLIOGRAFIA. Pasamos a usar o método máis comodo, xeral e rápido: CSL
@@ -576,9 +576,12 @@
 % :FACER: remirar estos conteos...
 % \pagenumbering{arabic}\setcounter{page}{1}
 
+%%%%%%%%%%%%%
+% DEFINICIÓNS
+%%%%%%%%%%%%%
 
-% outros macros e definicions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Acento gráfico ao lim
+\renewcommand{\lim}{\mathop{\mathrm{lím}}\limits}
 
-% para os diferenciais inexactos
+% Diferenciais inexactos
 \newcommand*{\dbar}{\ensuremath{\text{\dj}}}

--- a/revista.cls
+++ b/revista.cls
@@ -528,6 +528,18 @@
     }%
 }
 
+% CITAS TEXTUAIS
+%   Argumentos:
+%   #1: Contido da cita
+%   #2: Autor
+\newcommand{\Cita}[2]{%
+  \begin{quotation}
+  {\itshape #1}\\
+  \vspace{1ex}
+  \hfill — #2
+  \end{quotation}
+}
+
 \makeatother
 % Todos esos comandos teñen a info da revista. Gardase o valor nunha variable,
 % e imprimese no PDF con outro comando diferente. Esto da bastante

--- a/revista.cls
+++ b/revista.cls
@@ -167,7 +167,7 @@
 \RequirePackage{adforn}     %
 
 
-\RequirePackage{unicode-math}
+\RequirePackage[warnings-off={mathtools-colon,mathtools-overbracket}]{unicode-math}
 % :FACER: escoller outra tipografia para as mates, esta non ten varios simbolos
 % A maiores, teño a sospeita de que algúns simbolos e caracteres matemáticos funcionan mal,
 % véxase o de lim -> l1'm da revista_002 no pasatempo de alvaro

--- a/revista.cls
+++ b/revista.cls
@@ -26,9 +26,11 @@
 
 % Tipografía Sans Serif. Usase con \textsf{ aaa }
 \setsansfont[
-    Path      = ./fontes/LatinModern/,
-    Extension = .otf,
-]{lmsans10-regular}
+    Path        = ./fontes/LatinModern/,
+    Extension   = .otf,
+    UprightFont = *-regular,
+    BoldFont    = *-bold,
+]{lmsans10}
 
 % Tipografía xeral
 \setmainfont[
@@ -188,13 +190,14 @@
 % sola línea (por defecto, lo hace aunque hayas pedido justificación).
 % :FACER: tal vez podemos customizar algo mais as captions (sans serif?)
 \RequirePackage{caption}
+\renewcommand{\bfdefault}{bx}
 \captionsetup{
     font            = footnotesize,
     justification   = justified,
     skip            = 6pt,
     singlelinecheck = false,
-    labelfont       = {bf,small},
-    textfont        = {small}
+    labelfont       = {bf,sf,small},
+    textfont        = {sf,small}
 }
 
 % Uns paquetes varios que non organicei

--- a/revistas/002/artigo_PASATEMPOS.tex
+++ b/revistas/002/artigo_PASATEMPOS.tex
@@ -133,9 +133,11 @@ un bo momento esforzándose para as respostas tanto (ou tan pouco) como vexan
 oportuno. En base aos resultados, elaborarase unha clasificación á que se irán
 engadindo as cuestións dos seguintes números.
 
+\vspace{-3px}
 \begin{center}
     \includegraphics[width=0.8\linewidth]{revistas/002/imaxes/mapa.png}
 \end{center}
+\vspace{-3px}
 
 Nesta edición, queremos proporvos como reto unha serie de cuestións sobre a
 choiva na costa este verán. Para iso, tomaranse os datos da AEMET \textbf{dende
@@ -165,14 +167,11 @@ As cuestións a intentar predicir son as seguintes:
         se dará? Cal será o \textit{número máximo de días con
         precipitacións} entre as \textbf{13 estacións} e en cal se dará?
 \end{enumerate}
-
 O formulario é accesible a traves do Linktree e pecharase o \textbf{domingo 15
 de xuño ás 23:59} coa fin de evitar ter en conta predicións meteorolóxicas
 concretas, pero deixando moita marxe por estar en época de exames.
-
 \begin{center}
     \includegraphics[width=0.4\linewidth]{revistas/002/imaxes/pasatempos_momentum.png}
     \url{https://linktr.ee/pasatempos.momentum}
 \end{center}
-
 \end{multicols}

--- a/revistas/002/artigo_VOYAGER.tex
+++ b/revistas/002/artigo_VOYAGER.tex
@@ -8,19 +8,16 @@
 
 \subsection*{\textit{Na beira do océano cósmico}.}
 
-<<\textit{A superficie da Terra é a beira do océano cósmico. Dela aprendemos a
-maior parte do que sabemos. Recentemente metémonos un pouco no mar, vadeando o
-xusto para mollarnos os dedos dos pés ou, como moito, para que a auga nos
-chegase aos nocellos. A auga parece convidarnos a continuar. O océano chámanos.
-Hai unha parte de nós que sabe que vimos de alí. Desexamos volver. Non creo que
-estas aspiracións sexan irreverentes, mesmo se poden desagradar os deuses,
-sexan cales foren os posibles deuses.}>>
-
-%\vspace*{-1mm}
-%\begin{flushright}
-%Carl Sagan, \textit{Cosmos} (adaptación).
-%\end{flushright}
-\hfill Carl Sagan, \textit{Cosmos} (adaptación). \\
+\Cita{%
+A superficie da Terra é a beira do océano cósmico. Dela aprendemos a%
+maior parte do que sabemos. Recentemente metémonos un pouco no mar, vadeando o%
+xusto para mollarnos os dedos dos pés ou, como moito, para que a auga nos%
+chegase aos nocellos. A auga parece convidarnos a continuar. O océano chámanos.%
+Hai unha parte de nós que sabe que vimos de alí. Desexamos volver. Non creo que%
+estas aspiracións sexan irreverentes, mesmo se poden desagradar os deuses,%
+sexan cales foren os posibles deuses.%
+}%
+{Carl Sagan, \textit{Cosmos} (adaptación)}
 
 A misión de investigación espacial Voyager, fundada pola NASA, está constituída
 por dúas sondas interestelares irmás: a Voyager 1 e a Voyager 2.
@@ -195,17 +192,17 @@ As Voyager son un primeiro grito cheo de esperanza que a humanidade lanzou
 dende a beira do océano cósmico para darse a coñecer, unha mensaxe que di
 \textit{hai alguén aí?}. \\
 
-<<\textit{Quizais os rexistros nunca sexan interceptados. Quizais ninguén en
-cinco mil millóns de anos os atope. Cinco mil millóns de anos é moito tempo. En
-cinco mil millóns de anos, todos os seres humanos extinguiranse ou
-evolucionarán noutros seres, ningún dos nosos artefactos sobrevivirá na Terra,
-os continentes alteraranse ou destruiranse de forma irrecoñecible e a evolución
-do Sol queimará a Terra ata convertela en} `crumble' \textit{ou a reducirá a un
-remuíño de átomos.\\ Lonxe do fogar, intactas por estes acontecementos remotos,
-as Voyagers, portadoras das lembranzas dun mundo que xa non existe, seguirán
-voando.}>>
-
-\hfill Carl Sagan, \textit{Pale Blue Dot} (adaptación).
+\Cita{%
+Quizais os rexistros nunca sexan interceptados. Quizais ninguén en
+cinco mil millóns de anos os atope. Cinco mil millóns de anos é moito tempo. En%
+cinco mil millóns de anos, todos os seres humanos extinguiranse ou%
+evolucionarán noutros seres, ningún dos nosos artefactos sobrevivirá na Terra,%
+os continentes alteraranse ou destruiranse de forma irrecoñecible e a evolución%
+do Sol queimará a Terra ata convertela en `crumble' ou a reducirá a un%
+remuíño de átomos.\\ Lonxe do fogar, intactas por estes acontecementos remotos,%
+as Voyagers, portadoras das lembranzas dun mundo que xa non existe, seguirán%
+voando.}%
+{Carl Sagan, \textit{Pale Blue Dot} (adaptación)}
 
  % ao igual que antes hai que cambiar a cita
 


### PR DESCRIPTION
Introduce os seguintes cambios:

- Cambio de babel a polyglossia. `babel-galician` leva sin actualizarse dende 2008, debe usar un codificado raro porque non deixa modificar a definición de `\lim` para que apareza co acento gráfico. Cambiar a `[galician]{polyglossia}` soluciona isto. Algunhas cousas a ter en conta:
  - É máis compatíbel con prácticas de accesibilidade e con LuaLaTeX/XeLaTeX. Creo que pon o idioma como galego nos metadatos do pdf.
  - polyglossia fai moitos dos cambios nas traducións dos títulos, pero non os tipo `\sin -> sen`. Habería que definir estes macros ao final do revista.cls.
  - Como alternativa poderíamos empregar `babel-spanish` facendo os cambios pertinentes nos nomes.
- Cambio na fonte dos captions a sans-serif.
- Engadido un macro para as citas. Emprega `quotation` e xustifica á dereita o autor/obra/ano.
- Desactívase o aviso das redefinicións de unicode-math. Estas acontecen ao cargar mathtools xunto con unicode-math, o propio paquete ten unha opción para desactivalos.
- Soluciónase o da páxina en branco antes do índice na revista 002. Era causado polos restos do "Sobre Momentum" no ficheiro do índice. Habería que ver que facemos con isto se queremos que o núm.001 se amose como na impresión