### PR TITLE
Arranxar os avisos

### DIFF
--- a/bibliografia.bib
+++ b/bibliografia.bib
@@ -17,7 +17,7 @@
   Journal       = {Mathematische Annalen},
   Author        = {Carathéodory, C.},
   Year          = 1909,
-  Month         = sep,
+  Month         = {September},
   Pages         = {355–386},
   Language      = {de}
 }
@@ -329,7 +329,7 @@
   Publisher     = {Springer Science and Business Media LLC},
   Author        = {Demaine, Erik D. and Demaine, Martin L. and Minsky, Yair N. and Mitchell, Joseph S. B. and Rivest, Ronald L. and Pǎtraşcu, Mihai},
   Year          = 2013,
-  Month         = sep,
+  Month         = {September},
   Pages         = {531–550}
 }
 

--- a/fontes/LatinModern/lmsans10-oblique.otf
+++ b/fontes/LatinModern/lmsans10-oblique.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b38b36efc21f9d3f34edf6a13f9d71f59c41f824e790f5d3ee5ba5b4936f377
+size 101412

--- a/revista.cls
+++ b/revista.cls
@@ -592,6 +592,9 @@
 % PORTADA 
 %%%%%%%%%
 \long\def\Portada{%
+  % Esto de 'pageanchor' é para que non nos de un aviso do tipo
+  % ignoring duplicate destination with the same name 'page.1' etc.
+  \hypersetup{pageanchor=false}
   \pagenumbering{gobble}
   \thispagestyle{empty}
   
@@ -689,6 +692,7 @@
   
   % volvemos a cargar a xeometria que tiñamos no preambulo
   \restoregeometry
+  \hypersetup{pageanchor=true}
 }
 
 %%%%%%%%

--- a/revista.cls
+++ b/revista.cls
@@ -160,6 +160,14 @@
 \RequirePackage{diffcoeff}  % derivadas
 \RequirePackage{esint}      % integrais diferentes
 \RequirePackage{mathrsfs}   % letras reviradas \mathcal
+% Esto é para eliminar un waring do paquete mathrsfs
+% Véxase: https://tex.stackexchange.com/a/10701
+\DeclareFontFamily{U}{rsfs}{\skewchar\font127 }
+\DeclareFontShape{U}{rsfs}{m}{n}{%
+    <-6> rsfs5
+    <6-8> rsfs7
+    <8-> rsfs10
+}{}
 \RequirePackage{polynomial} % polinomios simples
 \RequirePackage{tensor}     % indices e eso
 \RequirePackage{braket} % :FACER: metin este porque alguen o tiña no artigo, non sei que fai

--- a/revista.cls
+++ b/revista.cls
@@ -29,6 +29,7 @@
     Path        = ./fontes/LatinModern/,
     Extension   = .otf,
     UprightFont = *-regular,
+    ItalicFont  = *-oblique,
     BoldFont    = *-bold,
 ]{lmsans10}
 

--- a/revista.cls
+++ b/revista.cls
@@ -159,18 +159,19 @@
 \RequirePackage{amsthm}     % definir teoremas
 \RequirePackage{diffcoeff}  % derivadas
 \RequirePackage{esint}      % integrais diferentes
+\RequirePackage{polynomial} % polinomios simples
+\RequirePackage{tensor}     % indices e eso
+\RequirePackage{braket} % :FACER: metin este porque alguen o tiña no artigo, non sei que fai
 \RequirePackage{mathrsfs}   % letras reviradas \mathcal
 % Esto é para eliminar un waring do paquete mathrsfs
-% Véxase: https://tex.stackexchange.com/a/10701
+% Orixe da solucion: https://tex.stackexchange.com/a/10701
+% Referencia de \DeclareFontShape: https://web.mit.edu/newtex/doc/latex/base/fntguide/node22.html
 \DeclareFontFamily{U}{rsfs}{\skewchar\font127 }
 \DeclareFontShape{U}{rsfs}{m}{n}{%
     <-6> rsfs5
     <6-8> rsfs7
     <8-> rsfs10
 }{}
-\RequirePackage{polynomial} % polinomios simples
-\RequirePackage{tensor}     % indices e eso
-\RequirePackage{braket} % :FACER: metin este porque alguen o tiña no artigo, non sei que fai
 
 % :FACER: seguimos necesitandoe stes dous paquetes?  vvvvvvvvvvv
 \RequirePackage{svrsymbols} % simbolos variados

--- a/revista.cls
+++ b/revista.cls
@@ -413,11 +413,15 @@
         }
     % Aplicamos o estilo de páxina
     \pagestyle{#2}%
-    % Aprobeito pa meter esto aquí. Resetea números nas ecuacións e
-    % figuras
-    \setcounter{equation}{0}
+    % Aprobeito pa meter esto aquí. Resetea números nas figuras
     \setcounter{figure}{0}
 }
+
+% Orixinalmente tamén cambiábamos a numeración das ecuacións dentro de
+% 'Titular' con '\setcounter{equation}{0}, pero dábanos warnings do tipo:
+% ignoring duplicate destination with the name 'equation.1'
+% asique pasamos a facelo deste modo
+\numberwithin{equation}{section}
 
 % Tipografia preciosa. Xoga cos espaciados moi ben para xustificar o texto.
 \RequirePackage{microtype}

--- a/revistas/002/artigo_LEEUWEN.tex
+++ b/revistas/002/artigo_LEEUWEN.tex
@@ -147,7 +147,7 @@ coma desaliñados: a mostra é diamagnética.\\
 En resumidas contas, de ser pola teoría clásica, non habería magnetismo
 posible, nunha clara contradición coa realidade experimental. Así, era
 necesaria unha nova teoría que fose capaz de explicar a presenza do magnetismo
-na natureza. Segundo \citet[pp. 354-355]{van-vleck.jh_1977}, foi este feito o
+na natureza. Segundo \cite{van-vleck.jh_1977}, foi este feito o
 que motivou a Bohr a introducir a cuantización do momento angular orbital do
 electrón ao redor do núcleo de hidróxeno para formular o seu famoso modelo
 atómico. Así, un pode afirmar que o nacemento da cuántica está moi vinculado ao


### PR DESCRIPTION
- `Module citeproc Warning: String name 'sep' is undefined.`
- `Font shape 'U/rsfs/m/n' in size <5.475> not available size <5> substituted on input line 187`
- `The option 'hypcap=true' will be ignored for this particular \caption on input line nnn` (en 67fed63d035ddf223562ee0c098f26147c63116d)
- `Some font shapes were not available, defaults substituted`
- `ignoring duplicate destination with the name '.....'`
- `LaTeX Warning: Command \showhyphens   has changed` (ca última update de Microtype)