### PR TITLE
Operadores matemáticos en galego

### DIFF
--- a/revista.cls
+++ b/revista.cls
@@ -874,11 +874,19 @@
     \end{minipage}
 }
 
-% DEFINICIÓNS
-% Un par de definicións, cousas pequenas
+% DEFINICIÓNS %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% Acento gráfico ao lim
+% Localización ao galego dos operadores matemáticos
+% Fonte: https://github.com/reutenauer/polyglossia/blob/b8a594cda8b55fab1234bc226b4aa52ddc4045a6/tex/gloss-spanish.ldf#L92
+% Notas: a abreviatura oficial de tanxente en galego é tan.
 \renewcommand{\lim}{\mathop{\mathrm{lím}}\limits}
+\renewcommand{\max}{\mathop{\mathrm{máx}}}
+\renewcommand{\min}{\mathop{\mathrm{mín}}}
+\renewcommand{\inf}{\mathop{\mathrm{ínf}}} % Elemento ínfimo
+\renewcommand{\mod}{\mathop{\mathrm{mód}}} % Módulo
+\renewcommand{\sin}{\mathop{\mathrm{sen}}}
+\renewcommand{\arcsin}{\mathop{\mathrm{arcsen}}}
+\renewcommand{\sinh}{\mathop{\mathrm{senh}}}
 
 % Diferenciais inexactos
 \newcommand*{\dbar}{\ensuremath{\text{\dj}}}


### PR DESCRIPTION
- Operadores con acento gráfico: lím, máx, mín, ínf, mód
- Operadores trigonométricos: sen, arcsen, senh

Creo que non esquezo ningún dos que se cambian en babel castelán e son comúns ao galego. Tamén se podería facer un pull ao repo de polyglossia.