### PR TITLE
Erro con CSL máis erro nos tags das ecuacións

### DIFF
--- a/revista.cls
+++ b/revista.cls
@@ -372,20 +372,16 @@
 % {}              -> sen subtitulo, debe ir cos parenteses baleiros
 %
 \NewDocumentCommand\Titular{ s m m m m }{%
-    % Primeiro, engadimos unha sección 'baleira'
-    \phantomsection%
     % Mostramos o propio titular, como sempre. Todo dentro dun `center`
     \begin{center}
         % Esto es para que cuando el texto ocupe más de dos líneas, se amplie
-        \vspace*{-5mm}
+        \vspace*{-2.5em}
         % TITULO
-        \begingroup
-            \setstretch{2}\noindent{\color{Resalte}\Huge \textbf{#3}} \\
-        \endgroup
+        \section*{\textcolor{Resalte}{\Huge \textbf{#3}}}
         % AUTORÍA
         \EstaBaleiro{#4}% comprobamos se a autoría está baleira
-            {\vspace*{3mm}}%                             --> se NON hai autor
-            {\vspace*{3mm}{\Large #4} \\ \vspace*{3mm}}% --> se SI hai autor
+            {\vspace*{3mm}}%                                           --> se NON hai autor
+            {\vspace*{3mm}{\vspace*{-1em}\Large #4} \\ \vspace*{3mm}}% --> se SI hai autor
         % SUBTITULO
         \EstaBaleiro{#5}% comprobamos se o subtitulo está baleiro
             {\vspace*{-3mm}}%               --> se NON hai subtitulo

--- a/revista.cls
+++ b/revista.cls
@@ -401,13 +401,20 @@
     \pagestyle{#2}%
     % Aprobeito pa meter esto aquí. Resetea números nas figuras
     \setcounter{figure}{0}
+    \setcounter{equation}{0}
+    % :FACER: se varias ecuacións teñen o mesmo tag, da un aviso do tipo:
+    %
+    % ignoring duplicate destination with the name 'equation.1'
+    %
+    % Creo que non se pode evitar a menos que teñan tags claramente diferenes.
+    % Se queremos que en cada artigo se vexan como (1), ..., (7), entón é
+    % imposible evitar os avisos (imos ter ecuacións co mesmo tag,
+    % necesariamente) Queda pendente probar se ao referenciar unha ecuación
+    % imos á que é ou no. Unha solución é que as ecuacións se numeren como
+    % (1.1), (1.2), (2.1), etc. así evitamos repeticions. Deixo varios macros
+    % acá porlas moscas \numberwithin{equation}{section}
+    % \renewcommand\theequation{\arabic{equation}}
 }
-
-% Orixinalmente tamén cambiábamos a numeración das ecuacións dentro de
-% 'Titular' con '\setcounter{equation}{0}, pero dábanos warnings do tipo:
-% ignoring duplicate destination with the name 'equation.1'
-% asique pasamos a facelo deste modo
-\numberwithin{equation}{section}
 
 % Tipografia preciosa. Xoga cos espaciados moi ben para xustificar o texto.
 \RequirePackage{microtype}

--- a/revista.cls
+++ b/revista.cls
@@ -401,7 +401,8 @@
     \pagestyle{#2}%
     % Aprobeito pa meter esto aquí. Resetea números nas figuras
     \setcounter{figure}{0}
-    \setcounter{equation}{0}
+    \stepcounter{section}
+    \counterwithin*{equation}{section}
     % :FACER: se varias ecuacións teñen o mesmo tag, da un aviso do tipo:
     %
     % ignoring duplicate destination with the name 'equation.1'

--- a/revista.cls
+++ b/revista.cls
@@ -403,15 +403,7 @@
     \setcounter{figure}{0}
     \stepcounter{section}
     \counterwithin*{equation}{section}
-    % :FACER: se varias ecuacións teñen o mesmo tag, da un aviso do tipo:
-    %
-    % ignoring duplicate destination with the name 'equation.1'
-    %
-    % Creo que non se pode evitar a menos que teñan tags claramente diferenes.
-    % Se queremos que en cada artigo se vexan como (1), ..., (7), entón é
-    % imposible evitar os avisos (imos ter ecuacións co mesmo tag,
-    % necesariamente) Queda pendente probar se ao referenciar unha ecuación
-    % imos á que é ou no. Unha solución é que as ecuacións se numeren como
+    % Outra opción é que as ecuacións se numeren como
     % (1.1), (1.2), (2.1), etc. así evitamos repeticions. Deixo varios macros
     % acá porlas moscas \numberwithin{equation}{section}
     % \renewcommand\theequation{\arabic{equation}}


### PR DESCRIPTION
- As ecuacións mostrábanse como (seccion.ecuación), cando debería ser so (ecuacion). Metin o erro en 767bebb sen querer para arranxar un aviso. Hai que volver atrás. Deixo todo comentado
- CSL 'refsection = section' non é compatible con `\phantomsection`, asique pasamos a usar seccións normais no macro `\Titular`

Son dúas contribucións independentes (decateime do das ecuación mentras facía o de CSL). Se tal podo facer 2 peticións separadas, tanto me da