### PR TITLE
apaño(clase): cambio disertacións por miscelánea

### DIFF
--- a/revista.cls
+++ b/revista.cls
@@ -318,9 +318,8 @@
 \definirEstiloEIndice{pasatempos}{Pasatempos}
 \definirEstiloEIndice{anuncios}{Anuncios}
 \definirEstiloEIndice{opinion}{Opinión}
-\definirEstiloEIndice{disertacions}{Microdisertacións}
+\definirEstiloEIndice{miscelanea}{Miscelánea}
 \definirEstiloEIndice{reportaxes}{Reportaxe}
-\definirEstiloEIndice{microdisertacions}{Micro Diseracións}
 
 \newcommand{\SeccionTOC}[1]{%
     \csname Indice#1\endcsname

--- a/revistas/003/artigo_OPINION.tex
+++ b/revistas/003/artigo_OPINION.tex
@@ -1,5 +1,5 @@
 \Titular*%
-{disertacions}%
+{miscelanea}%
 {Sobre a realidade do suxeito na física}%
 {}%
 {}%


### PR DESCRIPTION
Borrado o duplicado de microdisertacións e cambio deste apartado polo nome de miscelánea, tamén no artigo que o usa para mantelo funcional