### PR TITLE
apaño(fontes): engadir version oblicua de lmsans10

### DIFF
--- a/fontes/LatinModern/lmsans10-boldoblique.otf
+++ b/fontes/LatinModern/lmsans10-boldoblique.otf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e45673d84754a94f2f053bd4c15950b4b320144fbb622c630a26fd7b68cfabc5
+size 114984

--- a/revista.cls
+++ b/revista.cls
@@ -87,6 +87,7 @@
     UprightFont = *-regular,
     ItalicFont  = *-oblique,
     BoldFont    = *-bold,
+    BoldItalicFont = *-boldoblique,
 ]{lmsans10}
 
 


### PR DESCRIPTION
Facía falla para as preguntas da entrevista de Edelstein. Máis adiante, cando rematemos a 004, xa subirei o resto que queda (varias versións de lmmono)