### PR TITLE
docs: engadir ficheiro CITATION

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@
 cff-version: 1.2.0
 message: "Se desexas citar a revista estudantil 'Momentum', usa os metadatos deste ficheiro."
 title: "Momentum: a revista estudantil da Facultade de Física da USC"
-abstract: "Revista estudantil de carácter científico que busca fomentar e cultivar o interese e curiosidad pola física e a ciencia."
+abstract: "Revista estudantil de carácter científico que busca fomentar e cultivar o interese e curiosidade pola física e a ciencia."
 authors:
   - name: "Comité Editorial de Momentum"
     type: entity

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "Se desexas citar a revista estudantil 'Momentum', usa os metadatos deste ficheiro."
+type: periodical
+title: "Momentum: a revista estudantil da Facultade de Física da USC"
+abstract: "Revista estudantil de carácter científico que busca fomentar e cultivar o interese e curiosidad pola física e a ciencia."
+authors:
+  - name: "Comité Editorial de Momentum"
+    type: entity
+version: 1.0.0 # Versión inicial do ficheiro CFF
+date-released: 2025-01-01 # Collendo 2025 como ano de lanzamento
+url: https://github.com/fisicaUSC/revista
+repository-artifact: https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum
+
+publisher:
+  name: "Estudantado da Facultade de Física, USC"
+  type: entity
+  location: "Santiago de Compostela, Galiza"
+
+keywords:
+  - física
+  - ciencia
+  - divulgación científica
+  - revista estudantil
+  - publicación independente
+  - galego
+  - USC

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,20 +1,22 @@
+# Máis información: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files
+
 cff-version: 1.2.0
 message: "Se desexas citar a revista estudantil 'Momentum', usa os metadatos deste ficheiro."
-type: periodical
 title: "Momentum: a revista estudantil da Facultade de Física da USC"
 abstract: "Revista estudantil de carácter científico que busca fomentar e cultivar o interese e curiosidad pola física e a ciencia."
 authors:
   - name: "Comité Editorial de Momentum"
     type: entity
+    city: Santiago de Compostela
+    country: ES
+    region: Galiza
+    email: revistafisicaUSC@gmail.com
+
 version: 1.0.0 # Versión inicial do ficheiro CFF
 date-released: 2025-01-01 # Collendo 2025 como ano de lanzamento
-url: https://github.com/fisicaUSC/revista
-repository-artifact: https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum
-
-publisher:
-  name: "Estudantado da Facultade de Física, USC"
-  type: entity
-  location: "Santiago de Compostela, Galiza"
+url: >-
+  https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum
+repository-code: 'https://github.com/fisicaUSC/revista'
 
 keywords:
   - física
@@ -24,3 +26,16 @@ keywords:
   - publicación independente
   - galego
   - USC
+
+preferred-citation:
+  type: article
+  title: "Momentum: a revista estudantil da Facultade de Física da USC"
+  authors:
+   - name: "Comité Editorial de Momentum"
+     type: entity
+     city: Santiago de Compostela
+     region: Galiza
+     country: ES
+     email: revistafisicaUSC@gmail.com
+  url: >-
+    https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum


### PR DESCRIPTION
Estiven botando unha ollada á [documentación de git sobre ficheiros CITATION](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) e ao xerador de ficheiros [cffinit](https://citation-file-format.github.io/cff-initializer-javascript/#/start). Algunhas consideracións:

- Non hai un `type` que sexa explicitamente para publicacións periódicas: ao final escollín `article` porque me pareceu o máis axeitado, a outra opción é un tipo CFF `generic` e non me convence como sae a cita.
-  Na autoría puxen "Comité Editorial de Momentum", outras opcións poderían ser "Estudantado de Física da USC" ou "Mesa redonda da facultade ...". 

Petición para aceptar con aplastamento!!