### PR TITLE
comp(make): máis dependencias para a regra da revista

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SHELL := bash
 
 # esta accion mira se existe o arquivo revista/001/revista_001.tex e en caso
 # afirmativo, executa 'latexmk' con dito arquivo
-.pdf/revista_$(numero).pdf: revistas/$(numero)/revista_$(numero).tex
+.pdf/revista_$(numero).pdf: revistas/$(numero)/revista_$(numero).tex revista.cls momentum-citacions.csl logos/* fontes/NerdFonts/* fontes/LatinModern/* revistas/$(numero)/* revistas/$(numero)/imaxes/*
 	latexmk revistas/$(numero)/revista_$(numero).tex
 
 # accion para limpar os arquivos auxiliares


### PR DESCRIPTION
Antes Make só miraba para o arquivo principal da revista (revistas/xxx/revista_xxx.tex) polo que no caso de cambiar algún outro ficheiro (e.g. revista.cls) Make non detectaba ningún cambio. Non me din conta antes desta tontería porque teño o (malo) costume de borrar todos os datos da compilación cada vez (eu fago `make limpa && make numero=xxx` sempre).