### PR TITLE
apaño: usar Ghostscript para extraer a portada

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,23 @@ ifeq ($(cor),)
 cor := FF0000
 endif
 
-# Separar o PDF da revista en páxinas numeradas como .pdf/revista_001_3.pdf
-.pdf/paxinas_$(numero)_0.pdf: .pdf/revista_$(numero).pdf
-	magick .pdf/revista_$(numero).pdf .pdf/paxinas_$(numero)_%d.pdf
-	rm .pdf/paxinas_$(numero)_[0-9]?.pdf
-	rm .pdf/paxinas_$(numero)_[^0].pdf
+# Extrae a portada da revista
+# https://www.ghostscript.com/documentation/index.html
+.pdf/portada_$(numero).pdf: .pdf/revista_$(numero).pdf
+	gs \
+		-q \
+		-dBATCH \
+		-dNOPAUSE \
+		-dSAFER \
+		-sOutputFile=.pdf/portada_$(numero).pdf \
+		-sDEVICE=pdfwrite \
+		-dFirstPage=0 \
+		-dLastPage=1 \
+		-f .pdf/revista_$(numero).pdf
 
 # Xerar a propaganda. Esto usa Typst https://typst.app/ en lugar de LaTeX
 # Usase como 'make propaganda numero=004 cor=89fa3c'
-propaganda: .pdf/paxinas_$(numero)_0.pdf
+propaganda: .pdf/portada_$(numero).pdf
 	typst compile \
 		--diagnostic-format=short \
 		--root=. \
@@ -52,6 +60,6 @@ propaganda: .pdf/paxinas_$(numero)_0.pdf
 		--font-path=fontes \
 		--input numero=$(numero) \
 		--input cor=$(cor) \
-		trebellos/propaganda.typ .pdf/propaganda.pdf
+		trebellos/propaganda.typ .pdf/propaganda_$(numero).pdf
 
 .PHONY: limpa modelo propaganda

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 		-dSAFER \
 		-sOutputFile=.pdf/portada_$(numero).pdf \
 		-sDEVICE=pdfwrite \
-		-dFirstPage=0 \
+		-dFirstPage=1 \
 		-dLastPage=1 \
 		-f .pdf/revista_$(numero).pdf
 

--- a/trebellos/propaganda.typ
+++ b/trebellos/propaganda.typ
@@ -16,7 +16,7 @@
 )
 #set par( justify: true, first-line-indent: 0mm, leading : 0.4em)
 
-#let ruta_portada = "/.pdf/paxinas_" + sys.inputs.at("numero") + "_0.pdf"
+#let ruta_portada = "/.pdf/portada_" + sys.inputs.at("numero") + ".pdf"
 #let correo = "revistafisicaUSC@gmail.com"
 #let edicions = "https://www.usc.gal/gl/centro/facultade-fisica/revista-estudantil-momentum"
 


### PR DESCRIPTION
Imagemagick non é ideal para manipular PDFs. Ao extraer a portada facía unha imaxe e logo a imaxe pasábaa a PDF, o cal reducía a calidade.

A maiores, tamén cambiei os nomes de varios ficheiros