### PR TITLE
apaño(005): edicións varias, pés de foto, separadores decimais, etc.

### DIFF
--- a/revistas/005/artigo_ANA_PEON.tex
+++ b/revistas/005/artigo_ANA_PEON.tex
@@ -34,9 +34,9 @@ os cuantificadores $\forall,\, \exists$, e un signo especial para o cero. Con
 isto podemos establecer os axiomas ou normas básicas:
 %
 \begin{align*}
-    &\forall x,y          & & x+y=y+x\\
-    &\forall y            & & 0+y=y+0=y\\
-    &\forall x\ \exists y & & x+y=y+x=0\\
+    &\forall x,y          & & x+y=y+x,\\
+    &\forall y            & & 0+y=y+0=y,\\
+    &\forall x\ \exists y & & x+y=y+x=0,\\
     &\forall x,y,z        & & (x+y)+z=x+(y+z).
 \end{align*}
 %
@@ -49,7 +49,7 @@ mesmo tempo. E o mesmo aplica a calquera teoría das matemáticas: para o lóxic
 non é cuestión deste ou dese espazo, senón de todos á vez. Isto, que pode
 parecer pouco práctico, dá lugar a aplicacións impresionantes en análise, por
 exemplo, ou xeometría. E ademais poderedes contestar aos profesores de Métodos
-cando vos critiquen por riscardes o diferencial $dx$. En efecto, na teoría dos
+cando vos critiquen por riscardes o diferencial $\text{d}x$. En efecto, na teoría dos
 corpos ordenados, coma os números reais, existe un universo no que o
 diferencial é un número coma outro calquera, máis grande ca $0$, pero máis
 pequeno que tódolos reais positivos. Así que a riscar diferenciais sen
@@ -113,7 +113,7 @@ Hamilton (que son as mesmas que antes, pero son válidas nun contexto máis
 amplo, para tódolos sistemas hamiltonianos)
 %
 \begin{equation}
-    \dot{p}=\{H,p\}=-\frac{\partial H}{\partial q}
+    \dot{p}=\{H,p\}=-\frac{\partial H}{\partial q},
     \qquad
     \dot{q}=\{H,q\}=\frac{\partial H}{\partial p}
 \end{equation}
@@ -179,8 +179,8 @@ $e^{\frac{2k\pi i}{2}}$ para $k=0,1$. Para $N$ xeral, obteremos $e^{\frac{2k\pi
 i}{N}}$ para $k=0,\dots, N-1$. Este grupo $\mathbb{Z}_N$ (é un grupo
 esencialmente porque se poden multiplicar elementos e seguimos dentro, o $1$
 pertence a $\mathbb{Z}_N$, e ademais tódolos elementos teñen inverso)
-representa os posibles estadíos do sistema no punto $x$ sobre o que vive, ata
-enerxía $N$. Para conseguir tódolos estadíos enerexéticos haberá que
+representa os posibles estadios do sistema no punto $x$ sobre o que vive, ata
+enerxía $N$. Para conseguir tódolos estadios enerxéticos haberá que
 considerar tódolos $N$'s xuntos; isto non é problemático, pois as construcións
 son compatibles coa relación $N<N+1$, no sentido de que $L_N\subset L_{N+1}$, e
 as operacións de creación e aniquilación de $L_{N+1}$ inducen as de $L_N$.
@@ -220,7 +220,7 @@ reais da) a recta en cachiños $[x,x+1]$, seguimos tendo unha recta dentro. Por
 exemplo:
 %
 \begin{equation}
-    \mathbb{R}\longrightarrow [x,x+1] \qquad y\mapsto x+1-1/|y-x-1|.
+    \mathbb{R}\longrightarrow [x,x+1], \qquad y\mapsto x+1- \frac{1}{|y-x-1|}.
 \end{equation}
 %
 Certo, non está definida en $x+1$, por iso engadimos os infinitos en ámbolos
@@ -241,14 +241,14 @@ suma
 \begin{align}
     [\ell_1,y_1]+[\ell_2,y_2]\stackrel{\tiny\exists[\ell_1,y_2']=[\ell_2,y_2]}{=}
     &[\ell_1,y_1]+[\ell_1,y_2']\\
-    =&[\ell_1,y_1+y_2]
+    =&[\ell_1,y_1+y_2],
     \footnote{Exercicio: comproba que está ben definido!}
 \end{align}
 %
 sobre o que se poden definir os operadores
 %
 \begin{equation}
-0    a^\dagger[(e,y)]=[(e',yz)]\qquad a[(e',y)]=[(e,yz)]
+0    a^\dagger[(e,y)]=[(e',yz)],\qquad a[(e',y)]=[(e,yz)]
 \end{equation}
 %
 onde $(e,e',z)\in A^\dagger$, ou $(e',e,y)\in A$. Ben, a cuestión é que

--- a/revistas/005/artigo_CARBALLEIRA.tex
+++ b/revistas/005/artigo_CARBALLEIRA.tex
@@ -84,7 +84,7 @@ súa orixe... e tamén a do nome deste recuncho.
 
 \Cita%
 [Raúl de la Fuente Carballo, Óptica I]
-{Hai algunha neurona por aí que me está jodendo}
+{Hai algunha neurona por aí que me está jodendo.}
 
 \Cita%
 [Jaime, Mecánica Clásica I]
@@ -94,7 +94,7 @@ buenas. No tan inteligentes como las mías, pero buenas.}
 \Cita%
 [Vicente Muñuzuri, Física Xeral I]
 {Lo que tenemos es una esfera partida, como la canción de Corazón
-partido, pues una esfera partida…}
+partido, pues una esfera partida...}
 
 \Cita%
 [Vicente Muñuzuri, Física Xeral I]
@@ -108,7 +108,7 @@ esta facultad no, pero en las casas, sí.}
 \Cita%
 [Vicente Muñuzuri, Física Xeral I]
 {Tiene que dar cero la suma [diferencia de energía de un ciclo], es
-la prueba del algodón, -500-500+1200... Pues no da cero}
+la prueba del algodón, -500-500+1200... Pues no da cero.}
 
 \Cita%
 [Ana Peón, Métodos Matemáticos II]
@@ -118,16 +118,16 @@ dado espacio afín.}
 \Cita%
 [Carlos Merino, Teoría cuántica de campos]
 {Esta aula pertence á facultade de Física? Entón aquí aplica a Lei da
-Decana: non se pode beber auga, non se pode traer comida, nin bebida, nin nada}.
+Decana: non se pode beber auga, non se pode traer comida, nin bebida, nin nada.}
 
 \Cita%
 [Carlos Merino, Teoría cuántica de campos]
 {Non só nas relacións sociais ten que haber flow, senón tamén nas
-teorías cuánticas de campos}
+teorías cuánticas de campos.}
 
 \Cita%
 [Carlos Merino, Teoría cuántica de campos]
 {Manuel, podes saír un momento da aula? [...] Porque vou dicir unha
-frase… Para momentos grandes, non para grandes momentos…}
+frase… Para momentos grandes, non para grandes momentos...}
 
 \end{multicols}

--- a/revistas/005/artigo_CELIA.tex
+++ b/revistas/005/artigo_CELIA.tex
@@ -73,7 +73,7 @@ inevitábel paso do tempo e a morte.
 Outer Wilds non se centra en explicar a orixe desta perfecta harmonía entre os
 Nomai. É difícil contemplar unha traxectoria natural que leve ao ser humano a
 alcanzar un consenso global e a decidirnos e coordinarnos en busca de algo
-máis, que nos supere en dimensións pero que nos una. Polo camiño todavía queda
+máis, que nos supere en dimensións pero que nos una. Polo camiño aínda queda % todavía non existe
 moito para que a humanidade estea preparada para independizarse dos seus
 propios problemas. Pero mentres tanto esta ficción comparte un sentimento e
 penso que pode inspirar a realidade. Cada peza de arte garda significados

--- a/revistas/005/artigo_ENTREVISTA.tex
+++ b/revistas/005/artigo_ENTREVISTA.tex
@@ -37,8 +37,8 @@ cativou da física de partículas foi precisamente ver que detrás das teorías 
 desenvolvementos tecnolóxicos moi potentes, detectores, aceleradores,
 electrónica, cómputo, e esa mestura de ciencia e técnica é o que máis me
 interesa. Escollín iniciarme na investigación de partículas porque me permitía
-combinar esa curiosidade fundamental: “de que estamos feitos?”, “que leis
-gobernan o Universo?”, pero cunha dimensión práctica, de construción de
+combinar esa curiosidade fundamental: <<de que estamos feitos?>>, <<que leis
+gobernan o Universo?>>, pero cunha dimensión práctica, de construción de
 instrumentos e de análise de grandes volumes de datos.
 
 \Pregunta{%
@@ -55,7 +55,7 @@ instrumentos e de análise de grandes volumes de datos.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/mar_capeans.jpg}
-    \caption{Mar Capeáns no CERN (Foto de \textit{El País}).}
+    \caption{Mar Capeáns no CERN. (Foto: El País)}
 \end{figure}
 
 Creo que ás veces se percibe que as teorías teñen máis visibilidade, quizais
@@ -97,7 +97,7 @@ colectivo.
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/smq.jpg}
     \caption{
-        Proceso de fabricación de imáns para o High Luminosity LHC (Foto do CERN).
+        Proceso de fabricación de imáns para o High Luminosity LHC. (Foto: CERN)
     }
 \end{figure}
 
@@ -137,7 +137,7 @@ internacional.
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/swwwps.png}
     \caption{
-        Imaxe dunha recreación da primeira páxina web (Foto do CERN).
+        Imaxe dunha recreación da primeira páxina web. (Foto: CERN)
     }
 \end{figure}
 
@@ -168,7 +168,7 @@ sostible dun campus que funciona as 24 horas do día.
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/higos.jpg}
     \caption{
-        Celebración do descubrimento do Higgs (Foto de Maximilien Brice).
+        Celebración do descubrimento do Higgs. (Foto: Maximilien Brice)
     }
 \end{figure}
 

--- a/revistas/005/artigo_GABRIEL_RM.tex
+++ b/revistas/005/artigo_GABRIEL_RM.tex
@@ -49,7 +49,7 @@ Nos anos posteriores, leváronse a cabo numerosos intentos, nunca completamente
 exitosos, de unificar o electromagnetismo e a gravidade nun único marco teórico
 fundamental; entre eles, cabe mencionar a teoría de Kaluza-Klein. Nesta, o
 potencial $A_\mu$ (ou equivalentemente os campos $\textbf{E}$ e $\textbf{B}$,
-para @s menos familiarizad@s coa formulación covariante do electromagnetismo), %é incorrecta a linguaxe inclusiva con @, pero vou respectar as opinións do redactor (aínda que non as comparta)
+para as persoas menos familiarizadas coa formulación covariante do electromagnetismo), %é incorrecta a linguaxe inclusiva con @, pero vou respectar as opinións do redactor (aínda que non as comparta)
 representante da interacción electromagnética, introdúcese ó engadir
 formalmente unha quinta dimensión na teoría da relatividade xeral, e xogando
 coa súa xeometría a partir do funcional de acción \cite{KaluzaTh}. Porén, a
@@ -78,7 +78,7 @@ exemplo no campo da física atómica, e deu lugar a algunhas das predicións má
 precisas de toda a física. Existen varias maneiras de cuantizar o
 electromagnetismo clásico, sendo un dos métodos máis instrutivos o da integral
 de camiño de Feynman (para unha exposición pioneira e detallada véxase
-\cite{FH}). Para @ lector/-a curios@, cabe mencionar que, aínda a  %o uso aquí de @ é incorrecto, pero vouno deixar
+\cite{FH}). Para as persoas curiosas, cabe mencionar que, aínda a  %o uso aquí de @ é incorrecto, pero vouno deixar
 nivel clásico, as ecuacións de Maxwell poden derivarse en última instancia
 impoñendo que o lagranxiano que describe as partículas cargadas de spin $1/2$
 (como electróns), e que dá orixe á ecuación de Dirac, sexa invariante baixo o
@@ -327,21 +327,21 @@ leis da mecánica de buratos negros (véxase e.g. \cite{BHT}).
 Un problema (crucial, na opinión do autor) é a dificultade de elaborar
 experimentos que permitan detectar efectos cuánticos no nivel no que a
 gravidade xoga un papel importante. Como é ben sabido, a interacción
-gravitatoria é notoriamente máis feble que as outras tres, e a escala de enerxías
-que se debería acadar en aceleradores de partículas para comezar a observar
-devanditos efectos, algo inferior á chamada escala de Planck dada aproximadamente
-por $E_P \simeq \sqrt{\hbar c^5 / G} \sim 10^{19}$ GeV, non alcanzamos a comprendela
-actualidade por varias ordes de magnitude. Así e todo, existen tamén outros
-ámbitos nos que se están a propoñer ideas que nos poden achegar á determinación
-da natureza cuántica ou clásica da gravidade, como por exemplo experimentos
-relacionados coa decoherencia cuántica, que trata de explicar a transición
-entre os dominios cuántico e clásico dos sistemas físicos \cite{QD}. En
-calquera caso, todo parece indicar que a natureza está a xogar ás agachadas
-connosco, e que unha reformulación dos conceptos físicos máis fundamentais é,
-dalgún xeito, necesaria. Ó fin e ó cabo, como nos demostraron @s nos@s
-antepasad@s científic@s da primeira metade do século XX, as transformacións
-máis revolucionarias na nosa forma de comprender a natureza xorden de escapar
-de ideas preestablecidas.
+gravitatoria é notoriamente máis feble que as outras tres, e a escala de
+enerxías que se debería acadar en aceleradores de partículas para comezar a
+observar devanditos efectos, algo inferior á chamada escala de Planck dada
+aproximadamente por $E_P \simeq \sqrt{\hbar c^5 / G} \sim 10^{19}$ GeV, non
+alcanzamos a comprendela actualidade por varias ordes de magnitude. Así e todo,
+existen tamén outros ámbitos nos que se están a propoñer ideas que nos poden
+achegar á determinación da natureza cuántica ou clásica da gravidade, como por
+exemplo experimentos relacionados coa decoherencia cuántica, que trata de
+explicar a transición entre os dominios cuántico e clásico dos sistemas físicos
+\cite{QD}. En calquera caso, todo parece indicar que a natureza está a xogar ás
+agachadas connosco, e que unha reformulación dos conceptos físicos máis
+fundamentais é, dalgún xeito, necesaria. Ó fin e ó cabo, como nos demostrou a
+comunidade científica da primeira metade do século XX, as transformacións máis
+revolucionarias na nosa forma de comprender a natureza xorden de escapar de
+ideas preestablecidas.
 
 \printbibliography
 

--- a/revistas/005/artigo_GABRIEL_RM.tex
+++ b/revistas/005/artigo_GABRIEL_RM.tex
@@ -211,7 +211,7 @@ outras interaccións, que operan nos espazos internos como vimos de comentar.
 Interesante é tamén que observamos, por exemplo, que as partículas de carga
 nula non «senten» a interacción electromagnética (e similar para as
 interaccións nucleares coas propiedades físicas «internas» correspondentes).
-Por outra banda, tal e como indica a Ec. \eqref{eq:E_Eq}, toda a
+Por outra banda, tal e como indica a ecuación \eqref{eq:E_Eq}, toda a
 materia/enerxía interacciona a nivel gravitatorio sen excepción. Porén, aínda
 que é posible realizar analoxías matemáticas formais no ámbito da xeometría
 diferencial entre a relatividade xeral e o modelo estándar, parece existir unha
@@ -222,15 +222,21 @@ outros campos.
 Unha recopilación de \textit{approaches} históricos por cuantizar a %recopilación: forma menos recomendábel por recompilación
 relatividade xeral pode atoparse no capítulo 14 de \cite{W1984}. Pese a seren
 conceptualmente diferentes, tódolos formalismos acaban por chegar a un punto
-morto. Un dos máis populares escribe a métrica segundo $$g_{\mu \nu}(x) =
-\eta_{\mu \nu} + \gamma_{\mu \nu}(x),$$ onde se considera que $\gamma_{\mu
-\nu}$ é un campo que vive no espazo-tempo fixo de Minkowski usual dado por
-$\eta_{\mu \nu}$ e contén a información gravitatoria do sistema a considerar.
-Aquí, $x$ denota o conxunto de coordenadas espazo-temporais empregadas. O campo
-a cuantizar é, neste formalismo, $\gamma_{\mu \nu}$. Desafortunadamente, ó %aquí cambiei ao por ó, por coherencia co resto do texto
-tentar facer cálculos perturbativos típicos na teoría cuántica de campos para
-realizar predicións físicas, obtéñense diverxencias «non salvables» por todas
-partes, consecuencia da non-renormalizabilidade mencionada na sección anterior.
+morto. Un dos máis populares escribe a métrica segundo
+%
+\begin{equation}
+    g_{\mu \nu}(x) = \eta_{\mu \nu} + \gamma_{\mu \nu}(x),
+\end{equation}
+%
+onde se considera que $\gamma_{\mu \nu}$ é un campo que vive no espazo-tempo
+fixo de Minkowski usual dado por $\eta_{\mu \nu}$ e contén a información
+gravitatoria do sistema a considerar. Aquí, $x$ denota o conxunto de
+coordenadas espazo-temporais empregadas. O campo a cuantizar é, neste
+formalismo, $\gamma_{\mu \nu}$. Desafortunadamente, ó %aquí cambiei ao por ó,
+por coherencia co resto do texto tentar facer cálculos perturbativos típicos na
+teoría cuántica de campos para realizar predicións físicas, obtéñense
+diverxencias «non salvables» por todas partes, consecuencia da
+non-renormalizabilidade mencionada na sección anterior.
 
 Outro método amplamente considerado e máis adoptado para realizar cálculos non
 perturbativos é o da integral de camiño, particularmente ilustrativa á hora de

--- a/revistas/005/artigo_GABRIEL_RM.tex
+++ b/revistas/005/artigo_GABRIEL_RM.tex
@@ -21,9 +21,9 @@ XIX, cando os fenómenos da electricidade e do magnetismo, que inicialmente
 parecían desconexos, acadaron unha explicación conxunta con base no que
 coñecemos como a interacción electromagnética. A incompatibilidade entre esta e
 os principios da mecánica newtoniana atopou resolución co nacemento da
-relatividade especial, e posteriormente, a natureza non-relativista da
+relatividade especial, e posteriormente, a natureza non relativista da
 gravidade newtoniana, desembocou no nacemento da relatividade xeral en 1915: a
-teoría clásica actual (por clásica referímonos a non-cuántica) que explica a
+teoría clásica actual (por clásica referímonos a non cuántica) que explica a
 interacción gravitatoria a partir de deformacións do espazo e do tempo,
 producidos por materia e calquera tipo de enerxía en xeral. A xeometría do
 espazo-tempo 4-dimensional vén dada polo tensor métrico $g_{\mu \nu}$, que nos
@@ -40,7 +40,7 @@ enerxía-momento $T_{\mu \nu}$, segundo as ecuacións de Einstein:
 %
 sendo $R_{\mu \nu}$ e $R$ o tensor de Ricci e o escalar de curvatura,
 respectivamente, que dependen da métrica e das súas dúas primeiras derivadas
-espazo-temporais dun xeito altamente non-linear, e $\Lambda$, a constante %linear: forma menos recomendábel por lineal
+espazo-temporais dun xeito altamente non linear, e $\Lambda$, a constante %linear: forma menos recomendábel por lineal
 cosmolóxica. No límite de campo feble e velocidades moi inferiores a $c$, a
 ecuación \eqref{eq:E_Eq} redúcese á ecuación de Poisson para o potencial
 gravitatorio newtoniano usual $\Phi$ (principio de correspondencia).
@@ -77,8 +77,8 @@ electromagnetismo clásico non era capaz de describir de xeito preciso, por
 exemplo no campo da física atómica, e deu lugar a algunhas das predicións máis
 precisas de toda a física. Existen varias maneiras de cuantizar o
 electromagnetismo clásico, sendo un dos métodos máis instrutivos o da integral
-de camiño de Feynman (para unha exposición pioneira e detallada véxase a
-referencia \cite{FH}). Para @ lector/-a curios@, cabe mencionar que, aínda a  %o uso aquí de @ é incorrecto, pero vouno deixar
+de camiño de Feynman (para unha exposición pioneira e detallada véxase
+\cite{FH}). Para @ lector/-a curios@, cabe mencionar que, aínda a  %o uso aquí de @ é incorrecto, pero vouno deixar
 nivel clásico, as ecuacións de Maxwell poden derivarse en última instancia
 impoñendo que o lagranxiano que describe as partículas cargadas de spin $1/2$
 (como electróns), e que dá orixe á ecuación de Dirac, sexa invariante baixo o
@@ -93,7 +93,7 @@ complexa que a do electromagnetismo debido a non-linearidades nas ecuacións, en
 termos de teorías cuánticas de campos sobre as que se esixen certas simetrías
 internas básicas, particularmente $SU(2)$ para a interacción débil e $SU(3)$
 para a forte. Estas simetrías dan orixe, matematicamente, ós campos cuánticos
-que median as interacciones nucleares, a saber, os chamados bosóns $W^+$, $W^-$
+que median as interaccións nucleares, a saber, os chamados bosóns $W^+$, $W^-$
 e $Z^0$ no caso da interacción débil, e $g$ no caso da forte (son os análogos
 do fotón no caso da electrodinámica).
 
@@ -119,7 +119,7 @@ o que coñecemos como modelo estándar (SM) da física de partículas:
 Por si só, e a pesar de tódolos éxitos que acadou, o SM conta aínda con
 varios problemas teóricos e experimentais por resolver, o que deu lugar á busca
 de \textit{physics beyond the standard model} nas últimas décadas (véxase por
-exemplo a referencia \cite{BSM}). Entre eles, cabe mencionar o problema da masa
+exemplo \cite{BSM}). Entre eles, cabe mencionar o problema da masa
 dos neutrinos, cruciais nas interaccións débiles: o SM predí que estes teñen
 masa nula, pero experimentalmente atópase o contrario. A solución inmediata,
 que é engadir termos de masa para os mesmos en $\mathcal{L}_\text{SM}$,
@@ -153,12 +153,12 @@ fenomenoloxicamente, cuantizar o campo gravitatorio?
 Se ben non existe evidencia experimental directa de que a gravidade debe
 cuantizarse (e esta é quizais unha das maiores causas polas que aínda non se
 atopou unha teoría cuántica da gravidade satisfactoria), si existen varios
-argumentos ó seu favor. Un dos máis coñecidos é o que segue \cite{W1984}: se, a
+argumentos ó seu favor. Un dos máis coñecidos é o que segue: se, a
 nivel fundamental, os campos que representan diferentes tipos de materia, tanto
 fermións (e.g. electróns) como bosóns (e.g. fotóns), adoptan
 unha descrición cuántica, entón o tensor de enerxía-momento que aparece no
 membro dereito das ecuacións de Einstein \eqref{eq:E_Eq} convértese nun
-operador cuántico. Por exemplo, nun sistema no que o campo electromagnético
+operador cuántico \cite{W1984}. Por exemplo, nun sistema no que o campo electromagnético
 actúa como fonte da curvatura do espazo-tempo e unha descrición cuántica do
 campo é necesaria, tense
 %
@@ -304,7 +304,7 @@ ben o mundo macroscópico», coma o modelo estándar da física de partículas, 
 «explica ben o mundo microscópico», son, independentemente, teorías efectivas
 nos seus rangos de validez (como foi nos anos 30 do século pasado a teoría de
 Fermi da interacción débil), e que outras descricións máis fundamentais están
-aínda por ser descubertas. Dende a última métade do século pasado e á vista do
+aínda por ser descubertas. Dende a última metade do século pasado e á vista do
 fracaso de cuantizar a relatividade xeral por medio dos métodos tradicionais da
 teoría cuántica de campos, propuxéronse múltiples formalismos novos para
 resolver o problema da gravidade cuántica. Algúns deles desembocaron en
@@ -327,7 +327,7 @@ leis da mecánica de buratos negros (véxase e.g. \cite{BHT}).
 Un problema (crucial, na opinión do autor) é a dificultade de elaborar
 experimentos que permitan detectar efectos cuánticos no nivel no que a
 gravidade xoga un papel importante. Como é ben sabido, a interacción
-gravitatoria é notoriamente máis feble que as outras 3, e a escala de enerxías
+gravitatoria é notoriamente máis feble que as outras tres, e a escala de enerxías
 que se debería acadar en aceleradores de partículas para comezar a observar
 devanditos efectos, algo inferior á chamada escala de Planck dada aproximadamente
 por $E_P \simeq \sqrt{\hbar c^5 / G} \sim 10^{19}$ GeV, non alcanzamos a comprendela

--- a/revistas/005/artigo_GABRIEL_RM.tex
+++ b/revistas/005/artigo_GABRIEL_RM.tex
@@ -211,7 +211,7 @@ outras interaccións, que operan nos espazos internos como vimos de comentar.
 Interesante é tamén que observamos, por exemplo, que as partículas de carga
 nula non «senten» a interacción electromagnética (e similar para as
 interaccións nucleares coas propiedades físicas «internas» correspondentes).
-Por outra banda, tal e como indica a ecuación \eqref{eq:E_Eq}, toda a
+Por outra banda, tal e como indica a Ec. \eqref{eq:E_Eq}, toda a
 materia/enerxía interacciona a nivel gravitatorio sen excepción. Porén, aínda
 que é posible realizar analoxías matemáticas formais no ámbito da xeometría
 diferencial entre a relatividade xeral e o modelo estándar, parece existir unha
@@ -222,21 +222,15 @@ outros campos.
 Unha recopilación de \textit{approaches} históricos por cuantizar a %recopilación: forma menos recomendábel por recompilación
 relatividade xeral pode atoparse no capítulo 14 de \cite{W1984}. Pese a seren
 conceptualmente diferentes, tódolos formalismos acaban por chegar a un punto
-morto. Un dos máis populares escribe a métrica segundo
-%
-\begin{equation}
-    g_{\mu \nu}(x) = \eta_{\mu \nu} + \gamma_{\mu \nu}(x),
-\end{equation}
-%
-onde se considera que $\gamma_{\mu \nu}$ é un campo que vive no espazo-tempo
-fixo de Minkowski usual dado por $\eta_{\mu \nu}$ e contén a información
-gravitatoria do sistema a considerar. Aquí, $x$ denota o conxunto de
-coordenadas espazo-temporais empregadas. O campo a cuantizar é, neste
-formalismo, $\gamma_{\mu \nu}$. Desafortunadamente, ó %aquí cambiei ao por ó,
-por coherencia co resto do texto tentar facer cálculos perturbativos típicos na
-teoría cuántica de campos para realizar predicións físicas, obtéñense
-diverxencias «non salvables» por todas partes, consecuencia da
-non-renormalizabilidade mencionada na sección anterior.
+morto. Un dos máis populares escribe a métrica segundo $$g_{\mu \nu}(x) =
+\eta_{\mu \nu} + \gamma_{\mu \nu}(x),$$ onde se considera que $\gamma_{\mu
+\nu}$ é un campo que vive no espazo-tempo fixo de Minkowski usual dado por
+$\eta_{\mu \nu}$ e contén a información gravitatoria do sistema a considerar.
+Aquí, $x$ denota o conxunto de coordenadas espazo-temporais empregadas. O campo
+a cuantizar é, neste formalismo, $\gamma_{\mu \nu}$. Desafortunadamente, ó %aquí cambiei ao por ó, por coherencia co resto do texto
+tentar facer cálculos perturbativos típicos na teoría cuántica de campos para
+realizar predicións físicas, obtéñense diverxencias «non salvables» por todas
+partes, consecuencia da non-renormalizabilidade mencionada na sección anterior.
 
 Outro método amplamente considerado e máis adoptado para realizar cálculos non
 perturbativos é o da integral de camiño, particularmente ilustrativa á hora de

--- a/revistas/005/artigo_GABRIEL_RM.tex
+++ b/revistas/005/artigo_GABRIEL_RM.tex
@@ -331,17 +331,17 @@ gravitatoria é notoriamente máis feble que as outras tres, e a escala de
 enerxías que se debería acadar en aceleradores de partículas para comezar a
 observar devanditos efectos, algo inferior á chamada escala de Planck dada
 aproximadamente por $E_P \simeq \sqrt{\hbar c^5 / G} \sim 10^{19}$ GeV, non
-alcanzamos a comprendela actualidade por varias ordes de magnitude. Así e todo,
-existen tamén outros ámbitos nos que se están a propoñer ideas que nos poden
-achegar á determinación da natureza cuántica ou clásica da gravidade, como por
-exemplo experimentos relacionados coa decoherencia cuántica, que trata de
-explicar a transición entre os dominios cuántico e clásico dos sistemas físicos
-\cite{QD}. En calquera caso, todo parece indicar que a natureza está a xogar ás
-agachadas connosco, e que unha reformulación dos conceptos físicos máis
-fundamentais é, dalgún xeito, necesaria. Ó fin e ó cabo, como nos demostrou a
-comunidade científica da primeira metade do século XX, as transformacións máis
-revolucionarias na nosa forma de comprender a natureza xorden de escapar de
-ideas preestablecidas.
+alcanzamos a comprendela na actualidade por varias ordes de magnitude. Así e
+todo, existen tamén outros ámbitos nos que se están a propoñer ideas que nos
+poden achegar á determinación da natureza cuántica ou clásica da gravidade,
+como por exemplo experimentos relacionados coa decoherencia cuántica, que trata
+de explicar a transición entre os dominios cuántico e clásico dos sistemas
+físicos \cite{QD}. En calquera caso, todo parece indicar que a natureza está a
+xogar ás agachadas connosco, e que unha reformulación dos conceptos físicos
+máis fundamentais é, dalgún xeito, necesaria. Ó fin e ó cabo, como nos
+demostrou a comunidade científica da primeira metade do século XX, as
+transformacións máis revolucionarias na nosa forma de comprender a natureza
+xorden de escapar de ideas preestablecidas.
 
 \printbibliography
 

--- a/revistas/005/artigo_IAGO_AR.tex
+++ b/revistas/005/artigo_IAGO_AR.tex
@@ -44,12 +44,12 @@ problemas), decidiu darlle os datos de Marte. Sería con este planeta co que
 principalmente Kepler traballaría, o que é unha casualidade histórica: Marte é
 un dos planetas con órbitas máis excéntricas do Sistema Solar, polo que é máis
 doado chegar a resultados con el que co resto de planetas. Primeiro, repasemos uns
-detalles da astronomía kepleriana.
+detalles da astronomía prekepleriana.
 
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/0a.png}
-    \caption{Modelo tolemaico.}
+    \caption{Modelo tolemaico \cite{bizarre_mars}.}
 \end{figure}
 
 A astronomía tradicional aristotélica pon a Terra no centro tal que os planetas
@@ -83,7 +83,7 @@ desacelérase producindo este fenómeno (na seguinte imaxe vese mellor).
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/0b.png}
-    \caption{Retrogradación de Marte.}
+    \caption{Retrogradación de Marte \cite{bizarre_mars}.}
 \end{figure}
 
 Unha dificultade engadida fora que a Terra non era un observador fixo, senón
@@ -112,7 +112,7 @@ dos planetas non é constante.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/1.png}
-    \caption{Oposición Marte e ángulos do Sol e Terra.}
+    \caption{Oposición Marte e ángulos do Sol e Terra \cite{bizarre_mars}.}
 \end{figure}
 
 % \begin{figure}[H]
@@ -141,7 +141,7 @@ dos ángulos do zodíaco (vistos dende o Sol) que son os ángulos observacionais
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/3.jpg}
-    \caption{Variables e resultados da \textit{Hipótese Vicaria}.}
+    \caption{Variables e resultados da \textit{Hipótese Vicaria} \cite{bizarre_mars}.}
 \end{figure}
 
 Por un axuste de computación a forza bruta podemos achar o círculo único
@@ -164,10 +164,10 @@ distancia do Sol a Marte e ao centro da órbita.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/4.png}
-    \caption{Problema trigonométrico xerado polas dúas oposicións.}
+    \caption{Problema trigonométrico xerado polas dúas oposicións \cite{bizarre_mars}.}
 \end{figure}
 
-Kepler descubriu que, comparando a distancia Marte-Sol preditas e utilizadas
+Kepler descubriu que, comparando as distancias Marte-Sol preditas e utilizadas
 polo modelo, estas diverxían polo menos un 14\% e até un 42\% entre as calculadas coas
 medicións directas. Isto foi un gran problema, que fixo a Kepler dubidar cal
 sería o erro, se talvez é o círculo perfecto que se supón como órbita ou o
@@ -179,8 +179,8 @@ calculaban as predicións, agora devolvían un erro de oito arcominutos.
 
 Estes oito minutos son clave para revolucionar a astronomía. Non é un grande
 erro. O propio modelo de Tolomeo non baixaba dos dez arcominutos. Kepler non
-estaba convencido cos erros, xa que o das obervacións era na súa demasía de dous
-minutos. En lugar de ignoralo, entendeu que necesitaba buscar novas causas e
+estaba convencido cos erros, xa que o das observacións era na súa como moito de dous
+arcominutos. En lugar de ignoralo, entendeu que necesitaba buscar novas causas e
 sistemas e repensar todo o que fixera até agora, remeditar toda a astronomía.
 Que fan que se movan os planetas? Ninguén pretendera seriamente entender isto.
 Kepler imaxinou o Sol como un grande imán que facía unha forza que chamou
@@ -226,7 +226,7 @@ da Terra de maneira aproximada, xa que a sucesión de posicións revela a órbit
     \includegraphics[width=\linewidth]{revistas/005/imaxes/5.png}
     \caption{
         Debuxo do propio Kepler onde mostra a Marte na mesma posición, e a
-        posición da Terra despois de varios períodos de Marte.
+        posición da Terra despois de varios períodos de Marte \cite{kepler_2015}.
     }
 \end{figure}
 
@@ -246,7 +246,7 @@ Kepler chamaría \textit{ecuación óptica}. Por pura casualidade, tras analizar
 esta ecuación deuse de conta que en 5’30º o seu valor máximo, cando o ángulo do % os minutos e os graos escríbense na orde graosº minutos' segundos", tampouco sei se querería poñer segundos (") despois dos minutos
 centro e do Sol é de 90º, se tomamos a secante de 5’30º, o resultado daba
 1,0049. Xusto a distancia máxima máis un! Se modifica o seu modelo e axusta o
-seu método de epiciclos para facer que a distancia Marte-Sol fosen
+seu método de epiciclos para facer que as distancias Marte-Sol fosen
 proporcionais á secante da ecuación óptica, o seu modelo encaixaría coas
 observacións. Este complexo modelo xeométrico trazaba unha elipse perfecta.
 Aínda así, Kepler equivocouse inicialmente e, frustrado, desestimou este modelo.
@@ -260,7 +260,7 @@ que a segunda foi anterior á primeira).
     \includegraphics[width=\linewidth]{revistas/005/imaxes/6.png}
     \caption{
         Esquema do problema formulado coa curvatura de círculo perfecto e
-        observada, e a ecuación óptica e a secante.
+        observada, e a ecuación óptica e a secante \cite{bizarre_mars}.
     }
 \end{figure}
 
@@ -280,7 +280,7 @@ razón do triunfo da ciencia a futuro, a esperanza de que todos os fenómenos do
 mundo podían ter leis tan belas e simples.
 
 % \nocite{historia_marte}
-% \nocite{bizarre_mars}
+\nocite{bizarre_mars}
 \nocite{kepler_disc}
 \nocite{shoulders}
 \nocite{koestler_2017}

--- a/revistas/005/artigo_IAGO_AR.tex
+++ b/revistas/005/artigo_IAGO_AR.tex
@@ -264,7 +264,7 @@ que a segunda foi anterior á primeira).
     }
 \end{figure}
 
-\subsection*{Conclusión.}
+\subsection*{Conclusión}
 
 A principal motivación deste artigo é a de amosar a relevancia de todo este
 desenvolvemento. Na época de Kepler, os métodos científicos eran practicamente

--- a/revistas/005/artigo_MANUEL_GR.tex
+++ b/revistas/005/artigo_MANUEL_GR.tex
@@ -17,7 +17,7 @@ foi a súa estada por Santiago de Compostela en 1934.
 %O de estada non é unha errata por estadía, en galego normativo dise así.
 
 Desde 1911 véñense realizando as conferencias Solvay, unha serie de congresos
-sobre física e química (e desde abril de 2024 tamén de bioloxía) realizados en
+sobre física e química realizados en
 Bélxica. Foi nunha delas, en setembro de 1933, onde Blas Cabrera, que terá o
 papel de Jorge Mira na nosa historia, tivo o pracer de ser o primeiro físico
 español en participar, e tamén se cre que coñeceu alí en persoa a Schrödinger.
@@ -39,17 +39,15 @@ Casualmente, uns poucos días antes, tiña lugar en Galiza o XIV Congreso da Aso
 Española para el Progreso de las Ciencias\footnote{Concretamente, as
 conferencias estaba previsto que estivesen repartidas entre A Coruña, Santiago
 de Compostela, Pontevedra e Vigo.}, que reuniría máis de trescentos
-congresistas durante aproximadamente unha semana, comezando o mércores 1 de
+congresistas durante unha semana, comezando o mércores 1 de
 agosto de 1933. Por tanto, Cabrera tomou a decisión de convidar tamén a
 Schrödinger\footnote{Crese que foi quen o invitou, pero non se sabe con
 completa seguridade.}, para que dese alí unha charla sobre mecánica cuántica
 ondulatoria (Figura~\ref{charla}) o venres 3 de agosto ás 18:00 no Paraninfo
 (Santiago de Compostela).
 
-O discurso tratou de que, no contexto da revolución que supuxo a mecánica
-cuántica na física, non se deberían puír os conceptos cuestionados, senón que
-estes deberían substituírse completamente por outros, pois de non facerse isto,
-aparecería unha chea de contradicións. Despois, continuou destacando o papel
+O discurso tratou da revolución que supuxo a mecánica
+cuántica na física, onde destacou o papel
 das medicións na mecánica cuántica, e as súas diferenzas coa mecánica clásica.
 Máis tarde, tratou sobre as nocións de espazo e tempo dunha partícula, onde
 critica o concepto do sólido ríxido ideal: na mecánica cuántica só sistemas
@@ -57,7 +55,7 @@ infinitamente pesados poden considerarse ríxidos, pois os niveis enerxéticos
 son finitos. A conferencia remata resaltando a dificultade para reconciliar as
 dúas teorías da física moderna: a relatividade e a mecánica cuántica.
 
-O devandito congreso contou coa presenza non só de químicos ou físicos, senón
+O devandito congreso contou coa presenza
 de xente de todas as disciplinas\footnote{De feito, físicos eran máis ben
 poucos, pois Schrödinger comezou a súa intervención desculpándose do contido da
 súa comunicación, moi avanzado para a audiencia, poñendo como escusa a pouca
@@ -80,8 +78,8 @@ protagonista da nosa historia.
 A contraportada do \textit{El Pueblo Gallego} dese sábado describía en detalle
 o congreso, mais deixando a Schrödinger nunha posición inferior:
 
-\Cita{
-    SECCIÓN DE FÍSICA Y QUÍMICA Disertó ayer en esta sección el insigne premio
+\begin{adjustwidth}{1cm}{0.6cm}
+    \textit{SECCIÓN DE FÍSICA Y QUÍMICA Disertó ayer en esta sección el insigne premio
     Nobel, profesor Schrodinger, a quien sus ecuaciones diferenciales
     interpretativas de las teorías mecánico ondulatorias, así como sus matrices
     curicas (sic) harían suficientemente famoso, si otros muchos trabajos no
@@ -91,8 +89,8 @@ o congreso, mais deixando a Schrödinger nunha posición inferior:
     bárbaros odios de raza que no se detienen ante las cumbres de las ciencias.
     Tan solo en esta crónica daremos brevemente la nota periodística de la
     emoción enorme que produjo la presencia de este sabio en el auditorio que
-    ayer le escuchó en la Sección tercera.
-}
+    ayer le escuchó en la Sección tercera.}
+\end{adjustwidth}
 
 O sábado día 4, as conferencias do congreso trasladaríanse até A Coruña, onde
 Cabrera realizaría unha intervención. Non sabemos se Schrödinger acompañou a
@@ -118,11 +116,7 @@ unhas setenta persoas.
 De súpeto, mentres estaban os convidados nun bufete organizado polos marqueses
 de Camarasa, caeu o chan do salón (Figura~\ref{accidente}), precipitándose os
 alí presentes desde unha altura de 5 m, deixando gravemente feridas máis de
-cincuenta persoas e unha morte: a de María Luisa Gómez, profesora da Escola
-Normal de Vitoria. Entre os feridos estaba o cura de Oca, o director do
-Instituto de Santiago, Vicente García Rodeja, e Manuel Lora-Tamayo, químico e
-ministro de Educación posteriormente durante o franquismo. Este último, ao
-igual que outros dos que estaban alí, sufriu unha amputación da perna dereita.
+cincuenta persoas e unha morte.
 En definitiva, un desafortunado suceso que podería chegar pasar calquera día
 na nosa facultade (esperemos que non), tal e como está construída.
 

--- a/revistas/005/artigo_MAURO.tex
+++ b/revistas/005/artigo_MAURO.tex
@@ -58,7 +58,7 @@ estatístico é algo que pode resultar paradóxico.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/schrodinger1.png}
-    \caption{Alternativas do Gato de Schrödinger (Wikipedia)}
+    \caption{Alternativas do Gato de Schrödinger. (Foto: Wikipedia)}
     \label{schrodinger1}
 \end{figure}
 
@@ -90,7 +90,7 @@ cada punto do espazo.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/dobre_fenda.png}
-    \caption{Experimento da dobre fenda (Wikipedia).}
+    \caption{Experimento da dobre fenda. (Foto: Wikipedia)}
     \label{dobre_fenda}
 \end{figure}
 
@@ -136,8 +136,8 @@ ser vivo: «morto» e «vivo» son etiquetas que designan o estado de cada un
 dos átomos do gato cando o veleno é liberado e cando non o é, respectivamente.}
 %
 \begin{align}
-    \ket{\Psi} &= \frac{1}{\sqrt{2}}( \ket{1, \text{veleno}, \text{morto}}\\
-               &+ e^{i\Phi}\ket{0, \text{non veleno}, \text{vivo}} )
+    \ket{\Psi} =& \frac{1}{\sqrt{2}}( \ket{1, \text{veleno}, \text{morto}}\\
+               &+ e^{i\Phi}\ket{0, \text{non veleno}, \text{vivo}} ).
 \end{align}
 %
 Pero isto non remata aquí: como accedemos a este estado? A través dun detector.
@@ -147,8 +147,8 @@ humano tamén valería). En calquera caso, vemos que sucede o mesmo, que se dá 
 entrelazamento
 %
 \begin{align}
-    \ket{\Psi, D} &= \frac{1}{\sqrt{2}}( \ket{1, \text{veleno}, \text{morto}, M\,} \\
-                  &+ e^{i\Phi}\ket{0, \text{non veleno}, \text{vivo}, V\ } ).
+    \ket{\Psi, D} =& \frac{1}{\sqrt{2}}( \ket{1, \text{veleno}, \text{morto}, M} \\
+                  &+ e^{i\Phi}\ket{0, \text{non veleno}, \text{vivo}, V} ).
 \end{align}
 
 \begin{figure}[H]
@@ -188,7 +188,7 @@ ambos deben de ser ortogonais e á súa vez ser unha combinación de excitado e
 desexcitado.}
 %
 \begin{align}
-   \ket{1} \rightarrow & \frac{1}{\sqrt{2}} (\ket{0} + \ket{1}) \\
+   \ket{1} \rightarrow & \frac{1}{\sqrt{2}} (\ket{0} + \ket{1}), \\
    \ket{0} \rightarrow & \frac{1}{\sqrt{2}} (\ket{0} - \ket{1}).
 \end{align}
 %
@@ -202,7 +202,7 @@ De xeito que, se nos fixamos, por exemplo, na probabilidade de que o medidor de
 estado excitado se active
 %
 \begin{equation}
-    |\braket{1|\Psi}|^2 = \sin{}^2(\Phi/2)
+    |\braket{1|\Psi}|^2 = \sin{}^2(\Phi/2).
 \end{equation}
 %
 Obtemos interferencia! A existencia da fase fará que o átomo estea excitado con

--- a/revistas/005/artigo_SANTY_GG.tex
+++ b/revistas/005/artigo_SANTY_GG.tex
@@ -23,12 +23,12 @@ seguinte lectura, agora mundialmente famosa:
 \vspace*{-0.8em}
 
 \begin{center}
-    6 E Q U J 5
+    6 E Q U J 5.
 \end{center}
 
 \vspace*{-0.8em}
 
-Falamos dun sinal que, no seu pico, chegou a $30.5 \pm 0.5$ a intensidade do
+Falamos dun sinal que, no seu pico, chegou a $30{,}5 \pm 0{,}5$ a intensidade do
 fondo. Ehman rodeouno e comentouno cunha única palabra que acabou por darlle
 nome: \textit{Wow!}.
 
@@ -37,7 +37,7 @@ nome: \textit{Wow!}.
     \includegraphics[width=\linewidth]{./revistas/005/imaxes/wow.png}
     \caption{
         Detalle do printout no que Ehman observou o sinal
-        \textit{Wow!}. Imaxe de \cite{Ehman}.
+        \textit{Wow!} \cite{Ehman}.
     }
     \label{im:wow}
 \end{figure}
@@ -61,12 +61,12 @@ está prohibido empregala na Terra para transmisións de radio para non interfer
 coas medicións radioastronómicas. Primeiro, porque se observa moito: o
 hidróxeno é o elemento máis común no Universo e ademais pode emitir esta
 radiación espontaneamente. Segundo, porque corresponde a unha onda de radio que
-pode atravesar masas de pó opacas á luz, permitíndonos ver o que hai detrás.
+pode atravesar masas de po opacas á luz, permitíndonos ver o que hai detrás.
 
 \begin{figure}[H]
     \centering
     \includegraphics[width=0.9\linewidth]{./revistas/005/imaxes/perfil.png}
-    \caption{Perfil do sinal. Imaxe de Wikipedia.}
+    \caption{Perfil do sinal. (Foto: Wikipedia)}
     \label{im:perfil}
 \end{figure}
 
@@ -78,10 +78,10 @@ nosas sondas espaciais por se as atopasen intelixencias extraterrestres (en
 particular, as placas da Pioneer e o disco de ouro da Voyager), elixiuse
 precisamente a inversa desta frecuencia como unidade. Non sería esperable que
 seres intelixentes doutros planetas emitisen os seus sinais intergalácticos
-nesta frecuencia por idénticas razóns?\footnote{En
-\cite{morrison1959searching}, nun artigo 18 anos anterior á detección do sinal
-\textit{Wow!}, proponse $1420$ MHz como a frecuencia máis prometedora para
-procurar mensaxes dalgunha sociedade extraterrestre.}
+nesta frecuencia por idénticas razóns?\footnote{Nun artigo 18 anos anterior á
+    detección do sinal \textit{Wow!}, proponse $1420$ MHz como a frecuencia
+máis prometedora para procurar mensaxes dalgunha sociedade extraterrestre
+\cite{morrison1959searching}.}
 
 Se nos inclinamos pola teoría de que o sinal \textit{Wow!} ten orixe
 extraterrestre, unha pregunta natural sería, codificaba algún tipo de
@@ -144,14 +144,14 @@ Se cadra a explicación natural máis satisfactoria é a de
 radiación moito menos intensa proveniente de nubes de hidróxeno, os seus
 autores teorizan que o sinal \textit{Wow!} puido ser causado pola reemisión,
 por parte dunha destas nubes de hidróxeno, dalgún fenómeno superradiante, como
-un chorro dun magnétar (un tipo de púlsar cun fortísimo campo magnético) %non estou seguro de se habería que dicir magnétar ou magnetar, déixoo así por se acaso
+un chorro dun magnétar (un tipo de púlsar cun fortísimo campo magnético). %non estou seguro de se habería que dicir magnétar ou magnetar, déixoo así por se acaso
 
 \begin{figure}[H]
     \centering
     \includegraphics[width=0.75\linewidth]{./revistas/005/imaxes/reemision.png}
     \caption{
         Fenómeno de amplificación e reemisión dun chorro radiante por parte dunha
-        nube de hidróxeno. Imaxe de \cite{mendez2024arecibo}.
+        nube de hidróxeno \cite{mendez2024arecibo}.
     }
     \label{im:reemision}
 \end{figure}

--- a/revistas/005/artigo_SANTY_GG.tex
+++ b/revistas/005/artigo_SANTY_GG.tex
@@ -105,7 +105,7 @@ minutos antes. Como o sinal \textit{Wow!} só se detectou unha vez, temos unha
 de dúas posibilidades: ou a fonte transmitiu durante un período indeterminado
 antes do escáner da primeira rexión e extinguiuse nos 3 minutos que tardou en
 «chegar» a segunda rexión, ou a transmisión iniciouse nese intervalo de 3
-minutos entre escaneamentos \cite{Lemmino}. Sexa como for, todo apunta a que o
+minutos entre escaneamentos (\cite{Lemmino}). Sexa como for, todo apunta a que o
 sinal \textit{Wow!} foi un evento moi puntual, que tivemos moita sorte de
 captar e, en efecto, durante case 50 anos fomos incapaces de recibir outro sinal
 similar destas dúas rexións.

--- a/revistas/005/artigo_SANTY_GG.tex
+++ b/revistas/005/artigo_SANTY_GG.tex
@@ -105,7 +105,7 @@ minutos antes. Como o sinal \textit{Wow!} só se detectou unha vez, temos unha
 de dúas posibilidades: ou a fonte transmitiu durante un período indeterminado
 antes do escáner da primeira rexión e extinguiuse nos 3 minutos que tardou en
 «chegar» a segunda rexión, ou a transmisión iniciouse nese intervalo de 3
-minutos entre escaneamentos (\cite{Lemmino}). Sexa como for, todo apunta a que o
+minutos entre escaneamentos \cite{Lemmino}. Sexa como for, todo apunta a que o
 sinal \textit{Wow!} foi un evento moi puntual, que tivemos moita sorte de
 captar e, en efecto, durante case 50 anos fomos incapaces de recibir outro sinal
 similar destas dúas rexións.

--- a/revistas/005/artigo_SEBASTIAN_TP.tex
+++ b/revistas/005/artigo_SEBASTIAN_TP.tex
@@ -72,6 +72,8 @@ prendido cunha ollada. Todos estes detalles son coñecidos grazas á súa
 correspondencia e á descrición da biblioteca do rianxeiro que fai García-Sabell.
 Así, nunha carta que lle escribe a Cebreiro en 1922 figura:
 
+\vspace*{\fill}\null
+
 \Cita{Merquei algún libro para me «doutorar» nela [a teoría da relatividade]
 e agora ando tralo seguinte: Posto que a teoría da Relatividade demostra que o
 Tempo e o Espazo e outras cousas son máis ou menos longas asegundo o sistema de
@@ -148,7 +150,7 @@ dentro). Nun mesmo poema aparecen imaxes coespaciais cuxos verbos (que
 describen a acción) preséntanse tanto en pasado como en presente creando unha
 organización allea ao tempo lóxico. «Non hai cronoloxía obrigatoria,
 aínda que o ollo do lector tende a desprazarse desde a parte superior da páxina
-cara a abaixo.» \cite{march}
+cara a abaixo» \cite{march}.
 
 \begin{figure}[H]
     \centering
@@ -225,7 +227,9 @@ ao que se refire Baudelaire con «fondo») da obra de Manuel Antonio é
 irrecoñecible sen a física do momento. Non podo seguir descifrando o poemario
 nestas follas, non me queda máis que ir de catro en catro até que
 
-\Cita{Encherémo-las velas\\ ca luz náufraga da madrugada}
+\Cita{Encherémo-las velas\\ ca luz náufraga da madrugada.}
+\vspace*{\fill}\null
+
 
 \nocite{creacionismo}
 \nocite{d4a4}

--- a/revistas/005/artigo_VICTOR_DD.tex
+++ b/revistas/005/artigo_VICTOR_DD.tex
@@ -105,7 +105,7 @@ de fumar.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/caixa.png}
-    \caption{A caixa construida por Tait. Extraído de \cite{Tait}.}
+    \caption{A caixa construída por Tait \cite{Tait}.}
 \end{figure}
 
 A caixa producía aneis de fume que saían da súa boca e viaxaban polo aire,
@@ -148,7 +148,7 @@ nunha rama propia das matemáticas nos anos posteriores.
 \begin{figure}[H]
     \centering
     \includegraphics[width=\linewidth]{revistas/005/imaxes/nos.png}
-    \caption{Os sete nós máis sinxelos clasificados por Tait. Extraído de \cite{Silver}.}
+    \caption{Os sete nós máis sinxelos clasificados por Tait \cite{Silver}.}
 \end{figure}
 
 A idea tiña beleza e simplicidade, pero o seu fundamento científico estaba
@@ -200,10 +200,11 @@ formular as leis físicas intentouse, ademais, facelo de forma «bela e
 elegante». Isto non é necesariamente contraproducente, e ten sido útil
 nalgunhas ocasións. Pode axudar a descubrir conexións profundas e sutís entre
 diferentes conceptos da física matemática que non son evidentes nun primeiro
-momento, pero debe aplicarse con coidado para non caer en nesgos subxectivos e
+momento, pero debe aplicarse con coidado para non caer en sesgos subxectivos e % Entendo que nesgos é sesgos (que non existe en galego)
 convencerse de que unha teoría debe ser certa só pola súa beleza. Ao fin e ao
 cabo, a «beleza» nas matemáticas é un concepto fortemente subxectivo.
 
+\vspace*{\fill}\null
 \printbibliography
 
 \end{multicols}

--- a/revistas/005/revista_005.tex
+++ b/revistas/005/revista_005.tex
@@ -1,6 +1,6 @@
 \documentclass[completa]{revista}
 \Numero{005}
-\Data{Febreiro 2025}
+\Data{Febreiro 2026}
 \ImaxePortada{exemplo_imaxe.jpeg}
 \ComentarioImaxePortada{comentario}
 \Bibliografia{revistas/005/bibliografia_005.bib}


### PR DESCRIPTION
Sobre a revista 005:
- É lagranxian**o** ou lagranxian**a**??
- A linguaxe inclusiva con @ no artigo de Gabriel non pode quedar así...
  - Segundo a guía de linguaxe inclusiva e respectuosa coa diversidade da CIG: "Deberemos escoller o emprego da barra cando non atopemos ningún nome abstracto ou neutro que inclúa os xéneros nunha soa expresión". 
  - Vou a usar persoa en todo e para adiante. (Feito).

Cousas para engadir aos docs:
- As imaxes/figures referéncianse con \ref{...}, mentres que as ecuacións con \eqref{}.
- Os pies de imaxe foto con "Descrición [3]." ou "Descrición. (Foto: O que sexa)" Atención aos puntos finais!!
- Ao ter dúas columnas hai espazos que van a quedar mal case seguro. Pódese usar `\vspace*{\fill}\null` para axustar.
- Os adxectivos compostos en inglés tipo "non-quantum" tradúcense como "non cuántico", penso que en galego non se poden formar adxectivos cun "non-".