### PR TITLE
apaño: arranxado problema co parámetro quen da Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ INFO_GIT := \
 	--input rama=$(shell git rev-parse --abbrev-ref HEAD) \
 	--input hash=$(shell git rev-parse --short HEAD) \
 	--input dirt=$(shell test -z "$$(git status --porcelain)" && echo "" || echo "*") \
-	--input quen=$(shell git log -1 --format="%an")
+	--input quen="$(shell git log -1 --format="%an")"
 
 # Dependencias dun número.
 DEPENDENCIAS := \


### PR DESCRIPTION
Cando o nome do usuario de GitHub contén espazos, o comando de compilación de Typst, interpetaba os "apelidos" como o arquivo a compilar, polo que a compilación non se realizaba correctamente. Basta con poñer comiñas no parámetro para que funcione correctamente.